### PR TITLE
fix issue where most patterns could get hidden if audio was switched off

### DIFF
--- a/source/zc95/CSavedSettings.cpp
+++ b/source/zc95/CSavedSettings.cpp
@@ -221,7 +221,7 @@ void CSavedSettings::eeprom_initialise()
 {
     printf("Initialise EEPROM...\n");
     memset(_eeprom_contents, 0, sizeof(_eeprom_contents));
-    _eeprom_contents[(uint16_t)setting::EepromInit] = 0; // write this seperatly & last, in case something goes wrong mid way
+    _eeprom_contents[(uint16_t)setting::EepromInit] = 0; // write this separately & last, in case something goes wrong mid way
 
     // Set channels 0->internal Chan1, 1->internal chan2, etc..., and the rest to none
     for (int channel_id=0; channel_id < 4; channel_id++)

--- a/source/zc95/display/CMenuRoutineSelection.cpp
+++ b/source/zc95/display/CMenuRoutineSelection.cpp
@@ -169,5 +169,5 @@ void CMenuRoutineSelection::show()
 // If a routine has any menu item that uses audio, return true
 bool CMenuRoutineSelection::is_audio_routine(routine_conf conf)
 {
-    return (!(conf.audio_processing_mode != audio_mode_t::OFF));
+    return (conf.audio_processing_mode != audio_mode_t::OFF);
 }


### PR DESCRIPTION
With no audio board and audio set to Auto or Off, only the Audio patterns would display which is the exact opposite to what should happen.
Can be mostly worked around by going to Config -> Hardware Config -> Audio and setting it to "On (no gain)". Mostly, as it will then show all patterns (i.e. the non-applicable audio ones won't be hidden)