### PR TITLE
Allow eeprom to be cleared

### DIFF
--- a/docs/Build.md
+++ b/docs/Build.md
@@ -183,6 +183,14 @@ If any of the I2C devices aren't detected, you should see an error similar to th
 Here, it can't find the two ICs on the front panel (in this case, the IDC cable was unplugged).
 There is serial debugging output on the "Accessory" DB9 connector (tx pin 3, ground pin 5) on the front panel at RS232 levels.
 
+### Clearing saved settings / EEPROM
+So far I've never found it necessary, but the EEPROM can be reset to defaults by holding down the top right button and powering the box on. This will show a confirmation screen asking if it should be reset, then pressing bottom left button will clear it.
+Once reset, there should be an "EEPROM cleared" message, followed by flashing red lights. Power cycle the box, and it will have been reset to defaults.
+
+Before showing the confirmation screen, the box will have confirmed the EEPROM IC can be detected, but no saved settings will have been used. 
+
+EEPROM is used to store all settings that can be changed via the menus, but it does not store any uploaded Lua scripts - these are stored in flash, and can be wiped by reuploading the firmware. 
+
 ## ZC624 output module
 There is also debugging output from the ZC624 board on the serial header. Note that is at 3v3 level, and RS232 levels would damage it.
 
@@ -228,7 +236,7 @@ The process for self power-on calibration (for each channel) is:
 
 All this means is that an error like this:
 ```
-calibrate for sm=3 FAILED! final voltage = 0.011279, dac_value = 2600 (expecting 0.075v - 0.090v)
+calibrate for sm=3 FAILED! final voltage = 0.011279, dac_value = 2400 (expecting 0.075v - 0.090v)
 ```
 means that the PFET never switched on (enough) to complete calibration successfully.
 
@@ -239,9 +247,9 @@ calibrate for sm=3 FAILED! final voltage = 1.541235, dac_value = 3400 (expecting
 means the opposite - at the starting value of 3400, the voltage across the sense resistor (and therefore current flow though the PFET & transformer) was already way above what it should be.
 
 Possible causes (not exhaustive!) for calibration to fail:
-* If all channels are showing a similar and very low voltage (~0.01v) at a DAC value of 2600, suspect the 9v supply (and in turn, the 12v supply it's derived from)
+* If all channels are showing a similar and very low voltage (~0.01v) at a DAC value of 2400, suspect the 9v supply (and in turn, the 12v supply it's derived from)
 * Bad/incorrect PFET - e.g. not an IRF9Z24**NPBF**
-* Too low value sense resistor (if DAC value is 2600), or too high (if DAC value is 3400)
+* Too low value sense resistor (if DAC value is 2400), or too high (if DAC value is 3400)
 * Incorrect resistor value in the opamp circuit - likely if the final voltage is wildly off. Also suspect a bad/cracked resistor or poor solder joint if the final voltage keeps changing between power cycles 
 
 

--- a/source/zc95/CControlsPortExp.cpp
+++ b/source/zc95/CControlsPortExp.cpp
@@ -24,7 +24,7 @@
 
 /*
  * Deal with port expander U7, which:
- *   - reads input from front pannel buttons A, B, C & D
+ *   - reads input from front panel buttons A, B, C & D
  *   - is connected to IO1/2/3 on expansion header J17 (for optional audio input board)
  *   - controls the LCD backlight
  * 
@@ -50,7 +50,7 @@ void CControlsPortExp::clear_input()
     int retval = i2c_read(__func__, _address, &_last_read, 1, false);
     if (retval == PICO_ERROR_GENERIC || retval == PICO_ERROR_TIMEOUT)
     {
-      printf("CControlsPortExp::clear_intput i2c read error!\n");
+      printf("CControlsPortExp::clear_input i2c read error!\n");
     }
 
     _button_states_at_last_check = _last_read;

--- a/source/zc95/CHwCheck.cpp
+++ b/source/zc95/CHwCheck.cpp
@@ -1,6 +1,6 @@
 /*
  * ZC95
- * Copyright (C) 2021  CrashOverride85
+ * Copyright (C) 2023  CrashOverride85
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,6 +22,8 @@
 #include "CHwCheck.h"
 #include "i2c_scan.h"
 #include "config.h"
+#include "CUtil.h"
+#include "ECButtons.h"
 
 /*
  * Check for the presence of all expected i2c devices. If any are missing, flash the LEDs and try to display an 
@@ -39,8 +41,8 @@ CHwCheck::CHwCheck(CBatteryGauge *batteryGauge)
     _devices.push_front(device(ZC624_ADDR, "ZC624 output board", "ZC624"));
     
     // these two ICs are on the front panel
-    _devices.push_front(device(ADC_ADDR, "Front pannel ADC", "FP ADC U1"));
-    _devices.push_front(device(FP_ANALOG_PORT_EXP_2_ADDR, "Front pannel port expander (U2)", "FP Port Exp U2"));
+    _devices.push_front(device(ADC_ADDR, "Front panel ADC", "FP ADC U1"));
+    _devices.push_front(device(FP_ANALOG_PORT_EXP_2_ADDR, "Front panel port expander (U2)", "FP Port Exp U2"));
 
     // optional parts
     _devices.push_front(device(AUDIO_DIGIPOT_ADDR, "Digital potentiometer on audio board", "Audio digipot", true));
@@ -122,6 +124,9 @@ void CHwCheck::check_part1()
         led.init();
         hw_check_failed(cause, &led, NULL); // this never returns
     }
+
+    clear_eeprom_if_requested(); // if appropriate button is held down, clears eeprom then halts
+
 }
 
 // The ZC624 output board takes a while to initialize from power on, so check its status much later when it should be ready.
@@ -356,6 +361,82 @@ void CHwCheck::get_battery_readings()
     }
 
     _batteryGauge->add_raw_adc_readings(readings, sizeof(readings));
+}
+
+// Returns true if the top right button (C) is pressed, and the bottom left button (B)
+// is NOT pressed. This in case there's some fault causing all buttons to be read as pressed,
+// we don't want to clear the EEPROM by mistake.
+// Should only be ran after inital h/w check has confirmed the port expander 
+// is present.
+bool CHwCheck::clear_eeprom_buttons_pressed()
+{
+    uint8_t pin_states = 0;
+    int retval = i2c_read(__func__, CONTROLS_PORT_EXP_ADDR, &pin_states, 1, false);
+    if (retval == PICO_ERROR_GENERIC || retval == PICO_ERROR_TIMEOUT)
+    {
+      printf("CHwCheck::clear_eeprom_buttons_pressed i2c read error!\n");
+      pin_states = 0;
+    }
+
+    bool button_pressed = (pin_states & (1 << (uint8_t)Button::C)) && 
+                         !(pin_states & (1 << (uint8_t)Button::B));
+
+    printf("CHwCheck::clear_eeprom_buttons_pressed(): button pressed = %d (pin state = %x)\n", button_pressed, pin_states);
+    return button_pressed;
+}
+
+// If the top right button is pressed, show a basic screen asking if the eeprom should be cleared.
+// To keep things simple (no need to worry about blocking, partially initialised stuff afterwards, 
+// etc.), once the confirmation screen is displayed, the only way out is a power cycle.
+void CHwCheck::clear_eeprom_if_requested()
+{
+    if (!clear_eeprom_buttons_pressed())
+        return;
+
+    // Ok, button is held down indicating eeprom should be cleared. Show confirmation screen.
+    // From this point on, the only way out is a power-cycle - either with or without
+    // clearing eeprom first
+    CLedControl led = CLedControl(PIN_LED, NULL);
+    led.init();
+    led.set_all_led_colour(LedColour::Blue);
+    led.loop();
+
+    hagl_init();
+    put_text("Clear EEPROM?", 0, 0, hagl_color(0xFF, 0xFF, 0xFF));
+    put_text("Yes", 0, (DISPLAY_HEIGHT-1) - 10, hagl_color(0xAA, 0xAA, 0xAA));
+    hagl_flush();
+
+    // Wait for bottom right (B) button to be pressed for ~100ms
+    while (1)
+    {
+        uint8_t pin_states = 0;
+        i2c_read(__func__, CONTROLS_PORT_EXP_ADDR, &pin_states, 1, false);
+
+        bool button_pressed = (pin_states & (1 << (uint8_t)Button::B));
+        if (button_pressed)
+        {
+            // Do crude debounce; re-read pin after 100ms and if button is still pressed reset EEPROM
+            sleep_ms(100);
+
+            i2c_read(__func__, CONTROLS_PORT_EXP_ADDR, &pin_states, 1, false);
+            button_pressed = (pin_states & (1 << (uint8_t)Button::B));
+
+            if (button_pressed)
+            {
+                // Time to reset the EEPROM!
+                printf("Clearing EEPROM at user request\n");
+
+                CEeprom eeprom = CEeprom(I2C_PORT, EEPROM_ADDR);
+                CSavedSettings settings = CSavedSettings(&eeprom);
+                settings.eeprom_initialise();
+
+                hagl_clear_screen();
+                put_text("EEPROM cleared!", 0, 0, hagl_color(0xFF, 0xFF, 0xFF));
+                hagl_flush();
+                halt(&led);
+            }
+        }
+    }
 }
 
 void CHwCheck::process()

--- a/source/zc95/CHwCheck.h
+++ b/source/zc95/CHwCheck.h
@@ -28,6 +28,8 @@ class CHwCheck
         std::string get_zc624_version();
         bool audio_digipot_found();
         void die(CLedControl *led_control, std::string error_message);
+        bool clear_eeprom_buttons_pressed();
+        void clear_eeprom_if_requested();
         static bool running_on_picow();
 
     private:

--- a/source/zc95/CSavedSettings.cpp
+++ b/source/zc95/CSavedSettings.cpp
@@ -25,7 +25,7 @@
  * Manage access and updating of settings saved to EEPROM.
  * Assumes 512byte EEPROM, and loads its contents into memory.
  * A blank EEPROM should be automatically initialized with default values on first 
- * run; a blank EEPROM is detected by the absense of EEPROM_MAGIC_VAL in location 0.
+ * run; a blank EEPROM is detected by the absence of EEPROM_MAGIC_VAL in location 0.
  */
 
 CSavedSettings::CSavedSettings(CEeprom *eeprom)
@@ -320,7 +320,7 @@ void CSavedSettings::eeprom_initialise()
         _eeprom_contents[(uint8_t)setting::ChannelIndex + (channel_id*2)] = channel_id;
     }
 
-    // Set any remaing channels to nothing
+    // Set any remaining channels to nothing
     for (int channel_id=4; channel_id < EEPROM_CHANNEL_COUNT; channel_id++)
     {
         _eeprom_contents[(uint8_t)setting::ChannelType  + (channel_id*2)] = (uint8_t)CChannel_types::channel_type::CHANNEL_NONE;

--- a/source/zc95/CSavedSettings.h
+++ b/source/zc95/CSavedSettings.h
@@ -7,7 +7,7 @@
 #define EEPROM_SIZE      512 // EEPROM is 4Kbit
 #define EEPROM_MAGIC_VAL  85 // If this is in setting::EepromInit, assume the eeprom has been initialised
 
-#define EEPROM_CHANNEL_COUNT 10 // Maximum number of configuerd channels that can be saved. Changing this invalidates EEPROM contents
+#define EEPROM_CHANNEL_COUNT 10 // Maximum number of configured channels that can be saved. Changing this invalidates EEPROM contents
 
 class CSavedSettings
 {
@@ -143,8 +143,8 @@ class CSavedSettings
         bool get_collar_config(uint8_t collar_id, struct collar_config &collar_conf);
         bool set_collar_config(uint8_t collar_id, struct collar_config &collar_conf);
 
-
         void eeprom_initialise();
+
     private:
         bool eeprom_initialised();
         

--- a/source/zc95/config.h
+++ b/source/zc95/config.h
@@ -5,11 +5,11 @@
 #define PATTERN_TEXT_OUTPUT_QUEUE_LENGTH 4 // Max number of queued text/debug messages from Core1 (so far just lua) to Core0
 
 #define ZC624_ADDR                  0x10
-#define EXT_INPUT_PORT_EXP_ADDR     0x21 // 3x I/O lines on front panel accesory port (p0-02), 4x for trigger inputs (p4-p7), 1x N/C (p3)
-#define CONTROLS_PORT_EXP_ADDR      0x22 // 4x front pannel buttons (p0-p03), 3x I/O lines on expansion header J17 (p4-p6), 1x LCD backlight (p7)
-#define FP_ANALOG_PORT_EXP_2_ADDR   0x26 // Port expander (U2) on the front pannel
+#define EXT_INPUT_PORT_EXP_ADDR     0x21 // 3x I/O lines on front panel accessory port (p0-02), 4x for trigger inputs (p4-p7), 1x N/C (p3)
+#define CONTROLS_PORT_EXP_ADDR      0x22 // 4x front panel buttons (p0-p03), 3x I/O lines on expansion header J17 (p4-p6), 1x LCD backlight (p7)
+#define FP_ANALOG_PORT_EXP_2_ADDR   0x26 // Port expander (U2) on the front panel
 #define AUDIO_DIGIPOT_ADDR          0x2C // Digital potentiometer used to set gain on audio board
-#define ADC_ADDR                    0x48 // ADC on front pannel, used for power control dials
+#define ADC_ADDR                    0x48 // ADC on front panel, used for power control dials
 #define EEPROM_ADDR                 0x50 
 
 
@@ -31,12 +31,12 @@
 
 // Other pins
 #define PIN_LED           10 // ws2812 LED chain
-#define PIN_CONTROLS_INT   7 // front pannel controls port expander interrupt pin
+#define PIN_CONTROLS_INT   7 // front panel controls port expander interrupt pin
 #define PIN_EXT_INPUT_INT 21 // external inputs port expander interrupt pin
 #define PIN_433TX          3 // 433Mhz transmitter pin
 
-#define PIN_FP_INT1       11 // front panel interupt 1 (U1) - 4x channel rot encoders
-#define PIN_FP_INT2        6 // front panel interupt 2 (U2) - 5x rot enoder buttons & 1x adjust rot encoer (+ 1x unused line)
+#define PIN_FP_INT1       11 // front panel interrupt 1 (U1) - 4x channel rot encoders
+#define PIN_FP_INT2        6 // front panel interrupt 2 (U2) - 5x rot encoder buttons & 1x adjust rot encoder (+ 1x unused line)
 
 
 // Output board SPI


### PR DESCRIPTION
Add ability to clear eeprom (#28 )

Pressing the top right button when powering on now shows a screen with a single option to clear EEPROM.
Shouldn't be necessary, but allows bad EEPROM settings to be ruled out easily if there are issues.
