### PR TITLE
Allow grouping menu items

### DIFF
--- a/docs/LuaNotes.md
+++ b/docs/LuaNotes.md
@@ -30,6 +30,7 @@ Config = {
         {
             type = "MIN_MAX",
             title = "Delay",
+            group = 0,
             id = 1,
             min = 100,
             max = 2000,
@@ -40,6 +41,7 @@ Config = {
          {
             type = "MULTI_CHOICE",
             title = "Output",
+            group = 0,
             id = 2,
             choices = {
                 {choice_id = 1, description = "Pulse"},
@@ -121,6 +123,7 @@ Config = {
             type = "MIN_MAX",
             title = "Delay",
             id = 1,
+            group = 0,
             min = 100,
             max = 2000,
             increment_step = 100,
@@ -131,6 +134,7 @@ Config = {
             type = "MULTI_CHOICE",
             title = "Output",
             id = 2,
+            group = 0,
             choices = {
                 {choice_id = 1, description = "Pulse"},
                 {choice_id = 2, description = "Constant"}
@@ -141,7 +145,10 @@ Config = {
 ```
 `name = "Toggle"` sets the name for the script - this is prefixed with `U:` then used on the patterns menu.
 
-A menu entry is displayed when the script is running for each item in `menu_items`; each must be given a unique id, numbered sequentially from 1. There are two types supported:
+A menu entry is displayed when the script is running for each item in `menu_items`; each must be given a unique id, numbered sequentially from 1.
+ _Optionally_, each item can be given a `group` number - this only has any affect when ran remotely using the GUI, and allows related options to be group together, instead of appearing in one long list (useful for scripts with many options).
+
+ There are two types supported:
 * `MIN_MAX` - shows a horizontal bar graph that can be changed between the set min/max using the adjust dial. The unit of measure (uom) text is displayed as suffix to the numeric value in the bar chart 
 * `MULTI_CHOICE` - used to show a menu option that allows for one of multiple settings to be picked. Each choice must have a unique id.
 

--- a/remote_access/pattern_gui.py
+++ b/remote_access/pattern_gui.py
@@ -95,29 +95,45 @@ class ZcPatternGui:
     pattern_options_frame = Frame(pattern_frame, width=400, height=400)
     pattern_options_frame.grid(row=1, column=0, padx=10, pady=5)
 
-    Label (pattern_options_frame, text="Soft button").grid(row=0, column=0, padx=5, pady=5, sticky=W)
-    soft_button = Button(pattern_options_frame, text=pattern["ButtonA"])
-    soft_button.grid(row=0, column=1, padx=5, pady=5)    
-    soft_button.bind("<ButtonPress>", self.SoftButtonPressed)
-    soft_button.bind("<ButtonRelease>", self.SoftButtonReleased)
+    # Only show soft button if text has been set for it
+    if len(pattern["ButtonA"]) > 0:
+      button_frame = Frame(pattern_options_frame, width=200, height=4, highlightbackground="blue", highlightthickness=2)
+      button_frame.grid(row=0, column=0, padx=10, pady=5, sticky="ew")
+
+      Label (button_frame, text="Soft button").grid(row=0, column=0, padx=5, pady=5, sticky=W)
+      soft_button = Button(button_frame, text=pattern["ButtonA"])
+      soft_button.grid(row=0, column=1, padx=5, pady=5)    
+      soft_button.bind("<ButtonPress>", self.SoftButtonPressed)
+      soft_button.bind("<ButtonRelease>", self.SoftButtonReleased)
 
     row = 1
     self.var_radio_buttons = {}
     self.progress = {}
     self.min_max_menus = {}
+    menu_row = {}
+
     for menu_item in pattern["MenuItems"]:
-      spacer_frame = Frame(pattern_options_frame, width=400, height=4, highlightbackground="blue", highlightthickness=2)
-      spacer_frame.grid(row=row, column=0, columnspan=2, padx=10, pady=5, sticky="ew")
-      row += 1
+      title = menu_item["Title"]
+
+      if "Group" in menu_item:
+        group = menu_item["Group"]
+      else:
+        group = 0
       
-      title = menu_item["Title"] 
+      if group in menu_row:
+        menu_row[group] = menu_row[group] + 1
+      else:
+        menu_row[group] = 0
+      
       if "UoM" in menu_item:
         if len(menu_item["UoM"]) > 0:
           title += " (" + menu_item["UoM"] + ")"
       
-      Label(pattern_options_frame, text=title).grid(row=row, column=0, padx=5, pady=5, sticky=W)
-      self.AddMenuOptions(pattern_options_frame, row, menu_item)
-      row += 1
+      menu_item_frame = Frame(pattern_options_frame, width=400, height=4, highlightbackground="blue", highlightthickness=2)
+      menu_item_frame.grid(row=row+menu_row[group], column=0+group, padx=10, pady=5, sticky="ew")
+      
+      Label(menu_item_frame, text=title).grid(row=row, column=0, padx=5, pady=5, sticky=W)
+      self.AddMenuOptions(menu_item_frame, row, menu_item)
       
   # Stolen from https://tkdocs.com/tutorial/text.html
   def WriteToLog(self, msg, error):

--- a/source/zc95/RemoteAccess/CMessageProcessor.cpp
+++ b/source/zc95/RemoteAccess/CMessageProcessor.cpp
@@ -359,7 +359,7 @@ void CMessageProcessor::send_pattern_detail(StaticJsonDocument<MAX_WS_MESSAGE_SI
     int msg_count = (*doc)["MsgId"];
     int id = (*doc)["Id"];
 
-    StaticJsonDocument<2000> response_message;
+    StaticJsonDocument<2500> response_message;
     response_message["Type"] = "PatternDetail";
     response_message["MsgId"] = msg_count;
 
@@ -387,6 +387,7 @@ void CMessageProcessor::send_pattern_detail(StaticJsonDocument<MAX_WS_MESSAGE_SI
             JsonObject menu_item = menu_items.createNestedObject();
             menu_item["Id"] = it->id;
             menu_item["Title"] = it->title;
+            menu_item["Group"] = it->group_id;
 
             switch (it->menu_type)
             {

--- a/source/zc95/core1/CPowerLevelControl.cpp
+++ b/source/zc95/core1/CPowerLevelControl.cpp
@@ -149,7 +149,7 @@ uint16_t CPowerLevelControl::get_max_power_level(uint8_t channel)
         return selected_power;
 }
 
-// Get the maximum power level (power level set on front pannel - 0-1000) that's being ramped up to
+// Get the maximum power level (power level set on front panel - 0-1000) that's being ramped up to
 uint16_t CPowerLevelControl::get_target_max_power_level(uint8_t channel)
 {
     if (channel >= MAX_CHANNELS)

--- a/source/zc95/core1/routines/CAudioIntensity.cpp
+++ b/source/zc95/core1/routines/CAudioIntensity.cpp
@@ -50,13 +50,13 @@ void CAudioIntensity::config(struct routine_conf *conf)
 
     conf->audio_processing_mode = audio_mode_t::AUDIO_INTENSITY;
 
-    struct menu_entry menu_mono;
+    struct menu_entry menu_mono = new_menu_entry();
     menu_mono.id = menu_ids::AUDIO_INTENSITY_MONO;
     menu_mono.title = "Mono";
     menu_mono.menu_type = menu_entry_type::AUDIO_VIEW_INTENSITY_MONO;
     conf->menu.push_back(menu_mono);
 
-    struct menu_entry menu_stereo;
+    struct menu_entry menu_stereo = new_menu_entry();
     menu_stereo.id = menu_ids::AUDIO_INTENSITY_STEREO;
     menu_stereo.title = "Stereo";
     menu_stereo.menu_type = menu_entry_type::AUDIO_VIEW_INTENSITY_STEREO;

--- a/source/zc95/core1/routines/CAudioThreshold.cpp
+++ b/source/zc95/core1/routines/CAudioThreshold.cpp
@@ -50,7 +50,7 @@ void CAudioThreshold::config(struct routine_conf *conf)
     conf->audio_processing_mode = audio_mode_t::THRESHOLD_CROSS_FFT;
 
     // menu entry 1: "Audio trigger"
-    struct menu_entry menu_audio;
+    struct menu_entry menu_audio = new_menu_entry();
     menu_audio.id = menu_ids::AUDIO_VIEW;
     menu_audio.title = "Audio trigger";
     menu_audio.menu_type = menu_entry_type::AUDIO_VIEW_SPECT;

--- a/source/zc95/core1/routines/CAudioVirtual3.cpp
+++ b/source/zc95/core1/routines/CAudioVirtual3.cpp
@@ -45,7 +45,7 @@ void CAudioVirtual3::config(struct routine_conf *conf)
 
     conf->audio_processing_mode = audio_mode_t::AUDIO3;
 
-    struct menu_entry menu_mono;
+    struct menu_entry menu_mono = new_menu_entry();
     menu_mono.id = menu_ids::AUDIO_VIRTUAL_3;
     menu_mono.title = "Audio view";
     menu_mono.menu_type = menu_entry_type::AUDIO_VIEW_VIRTUAL_3;

--- a/source/zc95/core1/routines/CAudioWave.cpp
+++ b/source/zc95/core1/routines/CAudioWave.cpp
@@ -48,13 +48,13 @@ void CAudioWave::config(struct routine_conf *conf)
 
     conf->audio_processing_mode = audio_mode_t::AUDIO3;
 
-    struct menu_entry menu_stereo_view;
+    struct menu_entry menu_stereo_view = new_menu_entry();
     menu_stereo_view.id = menu_ids::AUDIO_WAVE;
     menu_stereo_view.title = "Stereo view";
     menu_stereo_view.menu_type = menu_entry_type::AUDIO_VIEW_WAVE;
     conf->menu.push_back(menu_stereo_view);
 
-    struct menu_entry menu_triphase_view;
+    struct menu_entry menu_triphase_view = new_menu_entry();
     menu_triphase_view.id = menu_ids::AUDIO_WAVE;
     menu_triphase_view.title = "Triphase view";
     menu_triphase_view.menu_type = menu_entry_type::AUDIO_VIEW_VIRTUAL_3;

--- a/source/zc95/core1/routines/CBuzz.cpp
+++ b/source/zc95/core1/routines/CBuzz.cpp
@@ -60,7 +60,7 @@ void CBuzz::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::SIMPLE);
 
     // Game length
-    struct menu_entry menu_game_len;
+    struct menu_entry menu_game_len = new_menu_entry();
     menu_game_len.id = menu_ids::GAME_DURATION;
     menu_game_len.title = "Game length";
     menu_game_len.menu_type = menu_entry_type::MIN_MAX;
@@ -71,8 +71,8 @@ void CBuzz::config(struct routine_conf *conf)
     menu_game_len.minmax.current_value = DefaultGameLenghtSec;
     conf->menu.push_back(menu_game_len);
 
-    // Shock increment, pecentage points
-    struct menu_entry menu_shock_increment;
+    // Shock increment, percentage points
+    struct menu_entry menu_shock_increment = new_menu_entry();
     menu_shock_increment.id = menu_ids::SHOCK_INC_PP;
     menu_shock_increment.title = "Shock increment";
     menu_shock_increment.menu_type = menu_entry_type::MIN_MAX;
@@ -84,7 +84,7 @@ void CBuzz::config(struct routine_conf *conf)
     conf->menu.push_back(menu_shock_increment);
 
     // Initial power
-    struct menu_entry menu_inital_power;
+    struct menu_entry menu_inital_power = new_menu_entry();
     menu_inital_power.id = menu_ids::INITAL_POWER;
     menu_inital_power.title = "Inital shock power";
     menu_inital_power.menu_type = menu_entry_type::MIN_MAX;
@@ -96,7 +96,7 @@ void CBuzz::config(struct routine_conf *conf)
     conf->menu.push_back(menu_inital_power);
 
     // Shock length
-    struct menu_entry menu_shock_length;
+    struct menu_entry menu_shock_length = new_menu_entry();
     menu_shock_length.id = menu_ids::SHOCK_LENGTH;
     menu_shock_length.title = "Min shock length";
     menu_shock_length.menu_type = menu_entry_type::MIN_MAX;

--- a/source/zc95/core1/routines/CCamTrigger.cpp
+++ b/source/zc95/core1/routines/CCamTrigger.cpp
@@ -58,7 +58,7 @@ void CCamTrigger::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::SIMPLE);
 
     // menu entry 1: "Shock Length"
-    struct menu_entry menu_pulse_len;
+    struct menu_entry menu_pulse_len = new_menu_entry();
     menu_pulse_len.id = menu_ids::PULSE_LENGTH;
     menu_pulse_len.title = "Shock Length";
     menu_pulse_len.menu_type = menu_entry_type::MIN_MAX;
@@ -70,7 +70,7 @@ void CCamTrigger::config(struct routine_conf *conf)
     conf->menu.push_back(menu_pulse_len);
 
     // menu entry 2: "Camera delay"
-    struct menu_entry cam_delay;
+    struct menu_entry cam_delay = new_menu_entry();
     cam_delay.id = menu_ids::CAM_DELAY;
     cam_delay.title = "Camera delay";
     cam_delay.menu_type = menu_entry_type::MIN_MAX;

--- a/source/zc95/core1/routines/CClimb.cpp
+++ b/source/zc95/core1/routines/CClimb.cpp
@@ -57,7 +57,7 @@ void CClimb::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::FULL);
 
     // menu entry 1: "Duration" - a min/max entry in seconds 
-    struct menu_entry duration;
+    struct menu_entry duration = new_menu_entry();
     duration.id = menu_ids::CLIMB_DURATION;
     duration.title = "Duration";
     duration.menu_type = menu_entry_type::MIN_MAX;
@@ -69,7 +69,7 @@ void CClimb::config(struct routine_conf *conf)
     conf->menu.push_back(duration);
 
     // menu entry 2: "Reset after climb" - when reaching full power, start over or not?
-    struct menu_entry reset_after_climb;
+    struct menu_entry reset_after_climb = new_menu_entry();
     reset_after_climb.id = menu_ids::CLIMB_RESET;
     reset_after_climb.title = "Reset after climb";
     reset_after_climb.menu_type = menu_entry_type::MULTI_CHOICE;

--- a/source/zc95/core1/routines/CClimbPulse.cpp
+++ b/source/zc95/core1/routines/CClimbPulse.cpp
@@ -60,7 +60,7 @@ void CClimbPulse::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::SIMPLE);
 
     // menu entry 1: "Duration" - a min/max entry in seconds 
-    struct menu_entry duration;
+    struct menu_entry duration = new_menu_entry();
     duration.id = menu_ids::CLIMB_DURATION;
     duration.title = "Duration";
     duration.menu_type = menu_entry_type::MIN_MAX;
@@ -72,7 +72,7 @@ void CClimbPulse::config(struct routine_conf *conf)
     conf->menu.push_back(duration);
 
     // menu entry 2: "Reset after climb" - when reaching full power, start over or not?
-    struct menu_entry reset_after_climb;
+    struct menu_entry reset_after_climb = new_menu_entry();
     reset_after_climb.id = menu_ids::CLIMB_RESET;
     reset_after_climb.title = "Reset after climb";
     reset_after_climb.menu_type = menu_entry_type::MULTI_CHOICE;
@@ -82,7 +82,7 @@ void CClimbPulse::config(struct routine_conf *conf)
     conf->menu.push_back(reset_after_climb);
 
     // menu entry 3: "Pulse Duration" - a min/max entry in ms 
-    struct menu_entry pulse_duration;
+    struct menu_entry pulse_duration = new_menu_entry();
     pulse_duration.id = menu_ids::CLIMB_PULSE_DURATION;
     pulse_duration.title = "Pulse duration";
     pulse_duration.menu_type = menu_entry_type::MIN_MAX;

--- a/source/zc95/core1/routines/CFire.cpp
+++ b/source/zc95/core1/routines/CFire.cpp
@@ -50,8 +50,8 @@ void CFire::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::SIMPLE);
     conf->outputs.push_back(output_type::SIMPLE);
 
-    // menu entry 1: "Mode" - pulse for present length, or continous whilst button pressed
-    struct menu_entry menu_mode;
+    // menu entry 1: "Mode" - pulse for present length, or continuous whilst button pressed
+    struct menu_entry menu_mode = new_menu_entry();
     menu_mode.id = menu_ids::MODE;
     menu_mode.title = "Mode";
     menu_mode.menu_type = menu_entry_type::MULTI_CHOICE;
@@ -61,7 +61,7 @@ void CFire::config(struct routine_conf *conf)
     conf->menu.push_back(menu_mode);
 
     // menu entry 2: "Pulse"
-    struct menu_entry menu_pulse_len;
+    struct menu_entry menu_pulse_len = new_menu_entry();
     menu_pulse_len.id = menu_ids::PULSE_LENGTH;
     menu_pulse_len.title = "Pulse length";
     menu_pulse_len.menu_type = menu_entry_type::MIN_MAX;

--- a/source/zc95/core1/routines/CLuaRoutine.cpp
+++ b/source/zc95/core1/routines/CLuaRoutine.cpp
@@ -174,6 +174,7 @@ void CLuaRoutine::get_config(struct routine_conf *conf)
 
             entry.title = get_string_field("title");
             entry.id = get_int_field("id");
+            entry.group_id = get_int_field("group");
             std::string menu_type_str = get_string_field("type");
 
             menu_entry_type menu_type;

--- a/source/zc95/core1/routines/CPredicament.cpp
+++ b/source/zc95/core1/routines/CPredicament.cpp
@@ -58,7 +58,7 @@ void CPredicament::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::SIMPLE);
 
     // menu entry 1: "Trigger 1 invert"
-    struct menu_entry menu_trg1_inv;
+    struct menu_entry menu_trg1_inv = new_menu_entry();
     menu_trg1_inv.id = menu_ids::TRG1_INV;
     menu_trg1_inv.title = "Trigger1 invert";
     menu_trg1_inv.menu_type = menu_entry_type::MULTI_CHOICE;
@@ -68,7 +68,7 @@ void CPredicament::config(struct routine_conf *conf)
     conf->menu.push_back(menu_trg1_inv);
 
     // menu entry 2: "Trigger 2 invert"
-    struct menu_entry menu_trg2_inv;
+    struct menu_entry menu_trg2_inv = new_menu_entry();
     menu_trg2_inv.id = menu_ids::TRG2_INV;
     menu_trg2_inv.title = "Trigger2 invert";
     menu_trg2_inv.menu_type = menu_entry_type::MULTI_CHOICE;
@@ -78,7 +78,7 @@ void CPredicament::config(struct routine_conf *conf)
     conf->menu.push_back(menu_trg2_inv);
 
     // menu entry 3: "Logic" : and / or
-    struct menu_entry menu_logic;
+    struct menu_entry menu_logic = new_menu_entry();
     menu_logic.id = menu_ids::LOGIC_MODE;
     menu_logic.title = "Logic";
     menu_logic.menu_type = menu_entry_type::MULTI_CHOICE;
@@ -88,7 +88,7 @@ void CPredicament::config(struct routine_conf *conf)
     conf->menu.push_back(menu_logic);
 
     // menu entry 4 "Output invert" : Yes / No
-    struct menu_entry menu_output_inv;
+    struct menu_entry menu_output_inv = new_menu_entry();
     menu_output_inv.id = menu_ids::OUTPUT_INV;
     menu_output_inv.title = "Output invert";
     menu_output_inv.menu_type = menu_entry_type::MULTI_CHOICE;

--- a/source/zc95/core1/routines/CRoundRobin.cpp
+++ b/source/zc95/core1/routines/CRoundRobin.cpp
@@ -54,7 +54,7 @@ void CRoundRobin::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::SIMPLE);
 
     // menu entry 1: "Delay" - how long to wait before switching to next channel
-    struct menu_entry menu_speed;
+    struct menu_entry menu_speed = new_menu_entry();
     menu_speed.id = menu_ids::DELAY;
     menu_speed.title = "Delay";
     menu_speed.menu_type = menu_entry_type::MIN_MAX;
@@ -66,7 +66,7 @@ void CRoundRobin::config(struct routine_conf *conf)
     conf->menu.push_back(menu_speed);
 
     // menu entry 2: "pulse/cont." - pulse each channel, or toggle between each?
-    struct menu_entry menu_pulse_cont;
+    struct menu_entry menu_pulse_cont = new_menu_entry();
     menu_pulse_cont.id = menu_ids::PULSE_CONT;
     menu_pulse_cont.title = "Pulse/Cont.";
     menu_pulse_cont.menu_type = menu_entry_type::MULTI_CHOICE;

--- a/source/zc95/core1/routines/CRoutine.h
+++ b/source/zc95/core1/routines/CRoutine.h
@@ -81,6 +81,7 @@ struct audio_view
 struct menu_entry
 {
     uint8_t id;
+    uint8_t group_id; // Only relevant for display purposes when running patterns from the python GUI
     menu_entry_type menu_type;
     std::string title;
     struct min_max minmax;
@@ -167,6 +168,16 @@ class CRoutine
              choice.choice_id = choice_id;
              choice.choice_name = choice_name;
              return choice;
+        }
+
+        static struct menu_entry new_menu_entry()
+        {
+            struct menu_entry entry;
+            entry.id = 0;
+            entry.group_id = 0;
+            entry.title = "NOT SET";
+
+            return entry;
         }
 
         void simple_channel_set_power(uint8_t channel, uint16_t power)

--- a/source/zc95/core1/routines/CShockChoice.cpp
+++ b/source/zc95/core1/routines/CShockChoice.cpp
@@ -55,7 +55,7 @@ void CShockChoice::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::SIMPLE);
 
     // menu entry 1: "Choice frequency" - how often a choice needs to be made
-    struct menu_entry duration;
+    struct menu_entry duration = new_menu_entry();
     duration.id = menu_ids::CHOICE_FREQUENCY;
     duration.title = "Choice frequency";
     duration.menu_type = menu_entry_type::MIN_MAX;
@@ -67,7 +67,7 @@ void CShockChoice::config(struct routine_conf *conf)
     conf->menu.push_back(duration);
 
     // menu entry 2: "Shock increment" - how much to increment the shock by each time triggered
-    struct menu_entry menu_shock_inc;
+    struct menu_entry menu_shock_inc = new_menu_entry();
     menu_shock_inc.id = menu_ids::SHOCK_INC;
     menu_shock_inc.title = "Shock increment by";
     menu_shock_inc.menu_type = menu_entry_type::MIN_MAX;

--- a/source/zc95/core1/routines/CTens.cpp
+++ b/source/zc95/core1/routines/CTens.cpp
@@ -51,7 +51,7 @@ void CTens::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::FULL);
 
     // menu entry 1: "pulse width" - a min/max entry between 10-250
-    struct menu_entry pulse_width;
+    struct menu_entry pulse_width = new_menu_entry();
     pulse_width.id = menu_ids::PULSE_WIDTH;
     pulse_width.title = "Pulse width";
     pulse_width.menu_type = menu_entry_type::MIN_MAX;
@@ -63,7 +63,7 @@ void CTens::config(struct routine_conf *conf)
     conf->menu.push_back(pulse_width);
 
     // menu entry 2: "frequency"
-    struct menu_entry menu_frequency;
+    struct menu_entry menu_frequency = new_menu_entry();
     menu_frequency.id = menu_ids::FREQUENCY;
     menu_frequency.title = "Frequency";
     menu_frequency.menu_type = menu_entry_type::MIN_MAX;

--- a/source/zc95/core1/routines/CToggle.cpp
+++ b/source/zc95/core1/routines/CToggle.cpp
@@ -46,7 +46,7 @@ void CToggle::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::SIMPLE);
 
     // menu entry 1: "Speed" - a min/max entry between 500-4000
-    struct menu_entry menu_speed;
+    struct menu_entry menu_speed = new_menu_entry();
     menu_speed.id = menu_ids::SPEED;
     menu_speed.title = "Speed";
     menu_speed.menu_type = menu_entry_type::MIN_MAX;
@@ -58,7 +58,7 @@ void CToggle::config(struct routine_conf *conf)
     conf->menu.push_back(menu_speed);
 
     // menu entry 2: "pulse/cont." - pulse each channel, or toggle between each?
-    struct menu_entry menu_pulse_cont;
+    struct menu_entry menu_pulse_cont = new_menu_entry();
     menu_pulse_cont.id = menu_ids::PULSE_CONT;
     menu_pulse_cont.title = "Pulse/Cont.";
     menu_pulse_cont.menu_type = menu_entry_type::MULTI_CHOICE;

--- a/source/zc95/core1/routines/CTriggeredClimb.cpp
+++ b/source/zc95/core1/routines/CTriggeredClimb.cpp
@@ -65,7 +65,7 @@ void CTriggeredClimb::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::SIMPLE);
 
     // menu entry 1: "Climb duration" - how long (in seconds) it takes to reach maximum power
-    struct menu_entry duration;
+    struct menu_entry duration = new_menu_entry();
     duration.id = menu_ids::CLIMB_DURATION;
     duration.title = "Climb duration";
     duration.menu_type = menu_entry_type::MIN_MAX;
@@ -77,7 +77,7 @@ void CTriggeredClimb::config(struct routine_conf *conf)
     conf->menu.push_back(duration);
 
     // menu entry 2: "Shock increment" - how much to increment the shock by each time triggered
-    struct menu_entry menu_shock_inc;
+    struct menu_entry menu_shock_inc = new_menu_entry();
     menu_shock_inc.id = menu_ids::SHOCK_INC;
     menu_shock_inc.title = "Shock increment by";
     menu_shock_inc.menu_type = menu_entry_type::MIN_MAX;
@@ -89,7 +89,7 @@ void CTriggeredClimb::config(struct routine_conf *conf)
     conf->menu.push_back(menu_shock_inc);
 
     // menu entry 3: "Shock duration" - how long the shock should last in ms
-    struct menu_entry menu_shock_dur;
+    struct menu_entry menu_shock_dur = new_menu_entry();
     menu_shock_dur.id = menu_ids::SHOCK_DURATION;
     menu_shock_dur.title = "Shock duration";
     menu_shock_dur.menu_type = menu_entry_type::MIN_MAX;

--- a/source/zc95/core1/routines/CWaves.cpp
+++ b/source/zc95/core1/routines/CWaves.cpp
@@ -55,7 +55,7 @@ void CWaves::config(struct routine_conf *conf)
     conf->outputs.push_back(output_type::FULL);
 
     // menu entry 1: "Speed"
-    struct menu_entry speed;
+    struct menu_entry speed = new_menu_entry();
     speed.id = menu_ids::WAVES_SPEED;
     speed.title = "Speed";
     speed.menu_type = menu_entry_type::MIN_MAX;


### PR DESCRIPTION
Addresses #35 
Allows a `group` to be set against each menu item in a Lua script, and the python GUI groups these options together in columns. 
Has no affect when not running scripts remotely. 