### PR TITLE
Change the order of some includes

### DIFF
--- a/source/zc95/AudioInput/CAudio3Process.cpp
+++ b/source/zc95/AudioInput/CAudio3Process.cpp
@@ -16,9 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
-#include "CAudio3Process.h"
-#include "../globals.h"
 #include <stdlib.h>
+#include "../globals.h"
+#include "CAudio3Process.h"
 #include "pico/util/queue.h"
 
 /* Audio3 mode

--- a/source/zc95/CControlsPortExp.cpp
+++ b/source/zc95/CControlsPortExp.cpp
@@ -16,11 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
-#include "CControlsPortExp.h"
 #include "globals.h"
 #include "CUtil.h"
 #include "hardware/gpio.h"
 #include <string.h>
+#include "CControlsPortExp.h"
 
 /*
  * Deal with port expander U7, which:

--- a/source/zc95/CLuaStorage.h
+++ b/source/zc95/CLuaStorage.h
@@ -5,8 +5,8 @@
 #include <stdio.h>
 #include <string>
 #include <list>
-#include "CAnalogueCapture.h"
 #include "core1/CRoutineOutput.h"
+#include "CAnalogueCapture.h"
 
 extern mutex_t g_core1_suspend_mutex;
 extern struct semaphore g_core1_suspend_sem;


### PR DESCRIPTION
Change the order of some includes so that it will compile on
 arm-none-eabi-gcc (Arm GNU Toolchain 12.3.Rel1 (Build arm-12.35)) 12.3.1 20230626 on Linux, otherwise you get failures due to missing definitions of 'uint' etc

I didn't test this with other versions so it's possible the ordering will need more tweaking.