### PR TITLE
Update the debounce time to 25ms 

### DIFF
--- a/source/zc95/CControlsPortExp.cpp
+++ b/source/zc95/CControlsPortExp.cpp
@@ -94,7 +94,7 @@ bool CControlsPortExp::has_button_state_changed(enum Button button, bool *new_st
 
   if (button_state_changed)
   {
-    if (time_us_64() - _last_state_change[(uint8_t)button] < (10 * 1000) ) // 10ms
+    if (time_us_64() - _last_state_change[(uint8_t)button] < (25 * 1000) ) // 25ms debounce
       return false;
     else
       _last_state_change[(uint8_t)button] = time_us_64();


### PR DESCRIPTION
This was needed for the different push switches (E-Switch LP1OA1AB) I used. With 10ms we'd get menu items skipping. 