### PR TITLE
fix cmake errors

### DIFF
--- a/source/zc95/CMakeLists.txt
+++ b/source/zc95/CMakeLists.txt
@@ -84,26 +84,26 @@ add_executable(zc95
 
   display/CMenu.cpp
   display/CDisplay.cpp
-  display/CMainMenu
-  display/CMenuRoutineSelection
-  display/CMenuRoutineAdjust
-  display/CMenuSettings
-  display/CMenuChannelConfig
-  display/CMenuCollarConfig
-  display/CMenuCollarConfigSelected
-  display/CMenuSettingLedBrightnes
-  display/CMenuSettingPowerStep
-  display/CMenuSettingRampUpTime
-  display/CMenuSettingAbout
-  display/CMenuSettingAudio
-  display/CMenuSettingHardware
-  display/CMenuRemoteAccess
-  display/CMenuRemoteAccessConnectWifi
-  display/CMenuRemoteAccessSerial
-  display/CMenuApMode
-  display/COptionsList
-  display/CHorzBarGraph
-  display/CDisplayMessage
+  display/CMainMenu.cpp
+  display/CMenuRoutineSelection.cpp
+  display/CMenuRoutineAdjust.cpp
+  display/CMenuSettings.cpp
+  display/CMenuChannelConfig.cpp
+  display/CMenuCollarConfig.cpp
+  display/CMenuCollarConfigSelected.cpp
+  display/CMenuSettingLedBrightnes.cpp
+  display/CMenuSettingPowerStep.cpp
+  display/CMenuSettingRampUpTime.cpp
+  display/CMenuSettingAbout.cpp
+  display/CMenuSettingAudio.cpp
+  display/CMenuSettingHardware.cpp
+  display/CMenuRemoteAccess.cpp
+  display/CMenuRemoteAccessConnectWifi.cpp
+  display/CMenuRemoteAccessSerial.cpp
+  display/CMenuApMode.cpp
+  display/COptionsList.cpp
+  display/CHorzBarGraph.cpp
+  display/CDisplayMessage.cpp
 
   AudioInput/CMCP4651.cpp
   AudioInput/CAudio.cpp


### PR DESCRIPTION
Whilst adding build notes for #47, noticed errors from CMake, e.g.:

```
CMake Warning (dev) at CMakeLists.txt:31 (add_executable):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  File:
```
