### PR TITLE
Wrong pattern can be started with no audio hardware

### DIFF
--- a/source/zc95/display/CMenuRoutineSelection.cpp
+++ b/source/zc95/display/CMenuRoutineSelection.cpp
@@ -39,7 +39,7 @@ CMenuRoutineSelection::CMenuRoutineSelection(
     printf("CMenuRoutineSelection() \n");
     _display = display;
     _area = display->get_display_area();
-    _routine_disply_list = new COptionsList(display, _area);
+    _routine_display_list = new COptionsList(display, _area);
     _routines = routines;
     _buttons = buttons;
     _submenu_active = NULL;
@@ -55,10 +55,10 @@ CMenuRoutineSelection::~CMenuRoutineSelection()
 {
     printf("~CMenuRoutineSelection() \n");
 
-    if (_routine_disply_list != NULL)
+    if (_routine_display_list != NULL)
     {
-        delete _routine_disply_list;
-        _routine_disply_list = NULL;
+        delete _routine_display_list;
+        _routine_display_list = NULL;
     }
 
     if (_submenu_active)
@@ -86,10 +86,11 @@ void CMenuRoutineSelection::button_pressed(Button button)
         {
         if (button == Button::A) // Select
         {
-            CRoutines::Routine routine = (*_routines)[_routine_disply_list->get_current_selection()];
-            _last_selection = _routine_disply_list->get_current_selection();
+            uint8_t routine_id = _routine_display_list->get_current_selection_id();
+            CRoutines::Routine routine = (*_routines)[routine_id];
+            _last_selection = _routine_display_list->get_current_selection();
             set_active_menu(new CMenuRoutineAdjust(_display, routine, _buttons, _routine_output, _audio));
-            _routine_output->activate_routine(_routine_disply_list->get_current_selection());
+            _routine_output->activate_routine(routine_id);
         }
 
         if (button == Button::B) // "Config"
@@ -99,12 +100,12 @@ void CMenuRoutineSelection::button_pressed(Button button)
         
         if (button == Button::C) // "Up"
         {
-            _routine_disply_list->up();
+            _routine_display_list->up();
         }
 
         if (button == Button::D) // "Down"
         {
-            _routine_disply_list->down();
+            _routine_display_list->down();
         }
     }
 }
@@ -117,7 +118,7 @@ void CMenuRoutineSelection::adjust_rotary_encoder_change(int8_t change)
 
 void CMenuRoutineSelection::draw()
 {
-    _routine_disply_list->draw();
+    _routine_display_list->draw();
 }
 
 void CMenuRoutineSelection::show()
@@ -128,7 +129,7 @@ void CMenuRoutineSelection::show()
     _display->set_option_d("Down");
 
     // Get a list of routines to show
-    _routine_disply_list->clear_options();
+    _routine_display_list->clear_options();
     int index=0;
     for (std::vector<CRoutines::Routine>::iterator it = _routines->begin(); it != _routines->end(); it++)
     {
@@ -143,16 +144,16 @@ void CMenuRoutineSelection::show()
         else
             name = "(!)" + conf.name;
 
-        // Hide audio routies from menu if audio hardware not present. Show everything else.        
+        // Hide audio routines from menu if audio hardware not present. Show everything else.        
         if (!is_audio_routine(conf))
         {
-            _routine_disply_list->add_option(name, index);
+            _routine_display_list->add_option(name, index);
         }
         else
         {
             if (_audio->get_audio_hardware_state() != audio_hardware_state_t::NOT_PRESENT)
             {
-                _routine_disply_list->add_option(name, index);
+                _routine_display_list->add_option(name, index);
             }
         }
 
@@ -164,7 +165,7 @@ void CMenuRoutineSelection::show()
     // of going back to the top of the list
     if (_last_selection > 0)
     {
-        _routine_disply_list->set_selected(_last_selection);
+        _routine_display_list->set_selected(_last_selection);
     }
 }
 

--- a/source/zc95/display/CMenuRoutineSelection.h
+++ b/source/zc95/display/CMenuRoutineSelection.h
@@ -47,7 +47,7 @@ class CMenuRoutineSelection : public CMenu
 
     private:
         bool is_audio_routine(routine_conf conf);
-        COptionsList *_routine_disply_list = NULL;
+        COptionsList *_routine_display_list = NULL;
         struct display_area _area;
         CDisplay* _display;
         std::vector<CRoutines::Routine> *_routines;


### PR DESCRIPTION
Fix issue where wrong pattern could be started if audio hardware not present (or disabled).
Closes #54 