### PR TITLE
Allow Lua Loop() frequency to be specified 

### DIFF
--- a/docs/LuaNotes.md
+++ b/docs/LuaNotes.md
@@ -326,6 +326,8 @@ Called once when the pattern is started, before `Loop()`. It can be used to do a
 ### Loop(time_ms)
 Called periodically for as long as the pattern is running. `time_ms` is how long in milliseconds the box has been powered on, and since v1.7 is a floating point number with microsecond precision. 
 
-`Loop()` is called as often as possible, but how often will depend enormously on how much work is done in the Loop() function - expect an empty Loop() to be called around every 50us, and a complex loop() to be called closer to every 4000us (or more).
+`Loop()` is called as often as possible by default, but how often will depend enormously on how much work is done in the Loop() function - expect an empty Loop() to be called around every 50us, and a complex loop() to be called closer to every 4000us (or more).
+
+If a specific frequency is required (rather than just as often as possible), a `loop_freq_hz = n` option can be added to the `Config = {}` block, where `n` is between 1 and 400. Be aware that for particularly complex scripts, higher values are unlikely to work well - and note that this setting will only reduce how often Loop() is called when compared to the default.
 
 [acc port]: images/lua_acc_port.png "Accessory port"

--- a/source/zc95/core1/routines/CLuaRoutine.cpp
+++ b/source/zc95/core1/routines/CLuaRoutine.cpp
@@ -135,7 +135,13 @@ void CLuaRoutine::load_lua_script_if_required()
 
 bool CLuaRoutine::is_script_valid()
 {
-    load_lua_script_if_required();
+    if (_script_valid == ScriptValid::INVALID)
+        return false;
+
+    routine_conf conf;
+    if (!get_and_validate_config(&conf))
+        return false;
+
     if (!_lua_state)
         return false;
 
@@ -173,9 +179,12 @@ bool CLuaRoutine::get_and_validate_config(struct routine_conf *conf)
         conf->button_text[(int)soft_button::BUTTON_A] = get_string_field("soft_button");
         int loop_freq = get_int_field("loop_freq_hz");
 
-        if (conf->loop_freq_hz < 0 || conf->loop_freq_hz > 400)
+        printf("loop_freq = %d\n", loop_freq);
+        if (loop_freq < 0 || loop_freq > 400)
         {
-            print(text_type_t::ERROR, "Configured loop_freq_hz of %d is not valid\n", conf->loop_freq_hz);
+            _last_lua_error = "Configured loop_freq_hz of " +  std::to_string(loop_freq) + " is not valid";
+            printf("%s\n", _last_lua_error.c_str());
+            conf->loop_freq_hz = 0; 
             is_valid = false;
         }
         else
@@ -231,6 +240,8 @@ bool CLuaRoutine::get_and_validate_config(struct routine_conf *conf)
 
     conf->name = "U:" + conf->name;
 
+
+    printf("get_and_validate_config: returning [%d]\n", is_valid);
     return is_valid;
 }
 

--- a/source/zc95/core1/routines/CLuaRoutine.h
+++ b/source/zc95/core1/routines/CLuaRoutine.h
@@ -15,6 +15,7 @@ class CLuaRoutine: public CRoutine
         ~CLuaRoutine();
         static CRoutine* create(uint8_t param) { return new CLuaRoutine(param); };
         void get_config(struct routine_conf *conf);
+        bool get_and_validate_config(struct routine_conf *conf);
         void menu_min_max_change(uint8_t menu_id, int16_t new_value);
         void menu_multi_choice_change(uint8_t menu_id, uint8_t choice_id);
         void soft_button_pushed (soft_button button, bool pushed);
@@ -60,7 +61,9 @@ class CLuaRoutine: public CRoutine
         int lua_set_freq(lua_State *L);
         int lua_set_pulse_width(lua_State *L);
         int lua_acc_io_write(lua_State *L);
-              
+        uint16_t _loop_freq_hz = 0;
+        uint32_t _last_loop = 0;
+
         lua_State *_lua_state;
         ScriptValid _script_valid = ScriptValid::UNKNOWN;
         uint64_t _channel_switch_off_at_us[CHANNEL_COUNT] = {0};

--- a/source/zc95/core1/routines/CRoutine.h
+++ b/source/zc95/core1/routines/CRoutine.h
@@ -97,6 +97,7 @@ struct routine_conf
     std::string button_text[(int)soft_button::BUTTON_MAX];
     bool enable_channel_isolation = true;
     audio_mode_t audio_processing_mode = audio_mode_t::OFF;
+    uint16_t loop_freq_hz = 0;
 };
 
 class CRoutine;


### PR DESCRIPTION
Allow Lua `Loop()` frequency to be specified using `loop_freq_hz = ` in the `Config = {}` section of Lua scripts. Acceptable values are 1-400, and the default if not present (or set to 0) is to call Loop() as often as possible, as per previous behaviour. 