### PR TITLE
Update LED display so Lua scripts don't just show solid red

### DIFF
--- a/source/zc624/CMessageProcess.cpp
+++ b/source/zc624/CMessageProcess.cpp
@@ -18,10 +18,8 @@ void CMessageProcess::init()
 {
     // SPI initialisation
     spi_init(SPI_PORT, SPI_BAUD_RATE);
-    
 
-   // spi_set_format(SPI_PORT, 8, SPI_CPOL_1, SPI_CPHA_1,SPI_MSB_FIRST);
-	spi_set_format(spi0, 8, SPI_CPOL_1, SPI_CPHA_1, SPI_MSB_FIRST);
+	spi_set_format(spi0, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
 
     spi_set_slave(SPI_PORT, true);
 
@@ -35,7 +33,7 @@ void CMessageProcess::loop()
 {
     message msg;
 
-    spi_read_blocking(SPI_PORT, (uint8_t)0x00, (uint8_t*)&msg, 4);
+    spi_read_blocking(SPI_PORT, _output->get_channel_led_state(), (uint8_t*)&msg, 4);
 //printf("command = %d, arg 0=%d, 1=%d, 2=%d\n", msg.command, msg.arg0, msg.arg1, msg.arg2);
     switch ((command)msg.command)
     {
@@ -55,7 +53,7 @@ void CMessageProcess::loop()
             set_freq(msg);
             break;
 
-        case command::SetPulseWitdh:
+        case command::SetPulseWidth:
             set_pulse_width(msg);
             break;
 
@@ -65,6 +63,10 @@ void CMessageProcess::loop()
 
         case command::SwitchOff:
             off(msg);
+            break;
+
+        case command::NoOp:
+            // Sent so we can send LED states 
             break;
 
         default:
@@ -114,7 +116,7 @@ void CMessageProcess::set_freq(message msg)
         _output->set_freq(msg.arg0, freq);
 }
 
-// SetPulseWitdh - set pulse width generated if SwitchOn used
+// SetPulseWidth - set pulse width generated if SwitchOn used
 // Args:
 // 0 = channel (0-3)
 // 1 = pos pulse width (us)

--- a/source/zc624/CMessageProcess.h
+++ b/source/zc624/CMessageProcess.h
@@ -24,11 +24,12 @@ class CMessageProcess
             PowerDown = 3,
 
             SetFreq = 4,
-            SetPulseWitdh = 5,
+            SetPulseWidth = 5,
             SwitchOn = 6,
-            SwitchOff = 7
+            SwitchOff = 7,
+            NoOp = 8
         };
-
+    
         CMessageProcess(COutput *output);
         ~CMessageProcess();
         void init();

--- a/source/zc624/COutput.cpp
+++ b/source/zc624/COutput.cpp
@@ -28,7 +28,7 @@ COutput::COutput(PIO pio, CI2cSlave *i2c_slave)
     _channel[3] = new COutputChannel(PIN_CHAN4_GATE_A, _pio, 3, _pio_program_offset, 1, &_dac, CDac::dac_channel::D, _pulse_queue);
 
     gpio_put(PIN_9V_ENABLE, 1);
-    sleep_ms(100); // wait for 9v suppy to stabalise
+    sleep_ms(100); // wait for 9v supply to stabilize
 
     for (int chan=0; chan < 4; chan++)
         _channel[chan]->calibrate();
@@ -145,12 +145,27 @@ void COutput::loop()
     }
 }
 
+uint8_t COutput::get_channel_led_state()
+{
+    uint8_t state = 0;
+    
+    for (uint8_t chan = 0; chan < CHANNEL_COUNT; chan++)
+    {
+        if (_channel[chan]->get_channel_led())
+        {
+            state |= (1 << chan);
+        }
+    }
+    
+    return state;
+}
+
 void COutput::power_down()
 {
     printf("COutput::power_down()\n");
     gpio_put(PIN_9V_ENABLE, 0);
     
-    // Could probably do with an extra status. But as there's currenly no return 
+    // Could probably do with an extra status. But as there's currently no return 
     // from PowerDown, it's good enough for now
     _i2c_slave->set_value((uint8_t)CI2cSlave::reg::OverallStatus, CI2cSlave::status::Fault); 
 

--- a/source/zc624/COutput.h
+++ b/source/zc624/COutput.h
@@ -25,6 +25,7 @@ class COutput
         void off(uint8_t channel);
         void loop();
         void power_down();
+        uint8_t get_channel_led_state();
 
     private:
         bool is_channel_valid(uint8_t channel);

--- a/source/zc624/COutputChannel.cpp
+++ b/source/zc624/COutputChannel.cpp
@@ -239,6 +239,7 @@ void COutputChannel::do_pulse(uint8_t pos_us, uint8_t neg_us)
     if (!pio_sm_is_tx_fifo_full(_pio, _sm))
     {
         pio_sm_put_blocking(_pio, _sm, val);
+        channel_led_on();
     }
     else
     {
@@ -246,13 +247,23 @@ void COutputChannel::do_pulse(uint8_t pos_us, uint8_t neg_us)
     }
 }
 
+void COutputChannel::channel_led_on()
+{
+    _channel_led_off_time_us = time_us_64() + (10 * 1000); // 10ms
+}
+
 COutputChannel::status COutputChannel::get_status()
 {
     return _status;
 }
 
-// test the PFET, by starting from the highist DAC setting which should turn the PFET fully off, and
-// runing through to 0, which should be fully on. Output the ADC reading for each DAC setting in a format
+bool COutputChannel::get_channel_led()
+{
+    return _channel_led_off_time_us > time_us_64();
+}
+
+// test the PFET, by starting from the highest DAC setting which should turn the PFET fully off, and
+// running through to 0, which should be fully on. Output the ADC reading for each DAC setting in a format
 // that can be easily imported into a spreadsheet for graphing. It should be a nice smooth curve starting
 // at around dac=3200 and leveling off around dac=1400
 void COutputChannel::diag_run_dac_sweep()

--- a/source/zc624/COutputChannel.h
+++ b/source/zc624/COutputChannel.h
@@ -29,12 +29,14 @@ class COutputChannel
         void do_pulse(uint8_t pos_us, uint8_t neg_us);
         status get_status();
         void diag_run_dac_sweep();
+        bool get_channel_led();
 
     private:
         static int cmpfunc (const void * a, const void * b);
         float get_adc_voltage();
         static bool s_timer_callback(repeating_timer_t *rt);
         bool timer_callback(repeating_timer_t *rt);
+        void channel_led_on();
         
         status _status;
         uint8_t _pin_gate_a;
@@ -53,6 +55,7 @@ class COutputChannel
         uint8_t _pulse_width_pos_us;
         bool _on;
         CPulseQueue *_pulse_queue;
+        volatile uint64_t _channel_led_off_time_us = 0;
 };
 
 #endif

--- a/source/zc624/config.h
+++ b/source/zc624/config.h
@@ -35,8 +35,8 @@
 
 
 #define DEVICE_TYPE   624
-#define VERSION_MAJOR   0
-#define VERSION_MINOR   3
+#define VERSION_MAJOR   1
+#define VERSION_MINOR   0
 
 
 

--- a/source/zc95/config.h
+++ b/source/zc95/config.h
@@ -16,8 +16,8 @@
 #define I2C_PORT i2c0  // main i2c bus for port expanders + eeprom
 
 // Set expected version for zc624 output module
-#define ZC624_REQUIRED_MAJOR_VERION 0
-#define ZC624_MIN_MINOR_VERION      3
+#define ZC624_REQUIRED_MAJOR_VERION 1
+#define ZC624_MIN_MINOR_VERION      0
 
 // Versions for the GetVersion/VersionDetails message, but that's not used by anything yet
 #define WEBSOCKET_API_VERION_MAJOR  1   // Increment on breaking change

--- a/source/zc95/core1/Core1.cpp
+++ b/source/zc95/core1/Core1.cpp
@@ -247,7 +247,7 @@ void Core1::process_messages()
 
 void Core1::process_message(message msg)
 {
-    printf("Core1::process_message(): got msg type %d (%d, %d, %d)\n", msg.msg8[0], msg.msg8[1], msg.msg8[2], msg.msg8[3]);
+    // printf("Core1::process_message(): got msg type %d (%d, %d, %d)\n", msg.msg8[0], msg.msg8[1], msg.msg8[2], msg.msg8[3]);
     switch (msg.msg8[0])
     {
     case MESSAGE_ROUTINE_LOAD:

--- a/source/zc95/core1/output/CFullChannelAsSimpleChannel.cpp
+++ b/source/zc95/core1/output/CFullChannelAsSimpleChannel.cpp
@@ -20,7 +20,7 @@
 #include "../config.h"
 
 /*
- * Allow a "full" output channel, e.g. the ZC624 output board (which expects pulse legnths to passed, etc.) to
+ * Allow a "full" output channel, e.g. the ZC624 output board (which expects pulse lengths to passed, etc.) to
  * be treated as a simple channel, which can be turned on/off and pulsed for x milliseconds
  */ 
 
@@ -29,7 +29,7 @@ CFullChannelAsSimpleChannel::CFullChannelAsSimpleChannel(CSavedSettings *saved_s
  CSimpleOutputChannel(saved_settings, power_level_control, channel_number) 
 {
     printf("CFullChannelAsSimpleChannel()\n");
-    _inital_led_colour = LedColour::Green;
+    _standby_led_colour = LedColour::Green;
     _off_time = 0;
     _full_channel = full_channel;
 
@@ -47,13 +47,11 @@ CFullChannelAsSimpleChannel::~CFullChannelAsSimpleChannel()
 
 void CFullChannelAsSimpleChannel::on()
 {
-    _full_channel->set_led_colour(LedColour::Red);
     _full_channel->on();
 }
 
 void CFullChannelAsSimpleChannel::off()
 {
-    _full_channel->set_led_colour(LedColour::Green);
     _full_channel->off();
 }
 
@@ -77,6 +75,8 @@ void CFullChannelAsSimpleChannel::loop(uint64_t time_us)
         off();
         _off_time = 0;
     }
+
+    _full_channel->loop(time_us);
 }
 
 bool CFullChannelAsSimpleChannel::is_internal()

--- a/source/zc95/core1/output/COutputChannel.h
+++ b/source/zc95/core1/output/COutputChannel.h
@@ -73,18 +73,14 @@ class COutputChannel
             return time_us_64();
         }
 
-        uint32_t _inital_led_colour = LedColour::Black;
+        uint32_t _standby_led_colour = LedColour::Black;
 
         void set_led_colour(uint32_t colour)
         {
             if (_channel_id >= 4)
                 return;
 
-            if (colour == _led_colour)
-                return;
-            else
-                _led_colour = colour;
-
+            _led_colour = colour;
 
             uint8_t blue  =  colour        & 0xFF;
             uint8_t green = (colour >>  8) & 0xFF;
@@ -98,7 +94,7 @@ class COutputChannel
 
             if (multicore_fifo_wready())
             {
-                // printf("core1: LED %d push %d\n", msg.msg8[0], colour );
+                // printf("core1: LED %d push %d\t%d\t%d\n", _channel_id, red, green, blue);
                 multicore_fifo_push_blocking(msg.msg32);
             }
             else

--- a/source/zc95/core1/output/ZC624Output/CZC624ChannelFull.h
+++ b/source/zc95/core1/output/ZC624Output/CZC624ChannelFull.h
@@ -29,7 +29,8 @@ class CZC624ChannelFull : public CFullOutputChannel
     private:
         CZC624Comms *_comms;
         uint8_t _channel_id;
-        uint64_t _led_off_time;
+        bool _last_led_state = false;
+        uint64_t _last_led_update_us = 0;
 };
 
 #endif

--- a/source/zc95/core1/output/ZC624Output/CZC624Comms.cpp
+++ b/source/zc95/core1/output/ZC624Output/CZC624Comms.cpp
@@ -1,8 +1,11 @@
 #include "../../../config.h"
 #include "../../../globals.h"
 #include "../../../CUtil.h"
+#include "../../../CLedControl.h"
+#include "../../Core1Messages.h"
 #include "CZC624Comms.h"
 
+#include "pico/multicore.h"
 #include "hardware/spi.h"
 #include <stdio.h>
 
@@ -26,7 +29,7 @@ CZC624Comms::CZC624Comms(spi_inst_t *spi, i2c_inst_t *i2c)
         gpio_set_function(PIN_OUTPUT_BOARD_SPI_CSN, GPIO_FUNC_SPI);
 
         spi_init(_spi, SPI_BAUD_RATE);
-        spi_set_format(spi0, 8, SPI_CPOL_1, SPI_CPHA_1, SPI_MSB_FIRST);
+        spi_set_format(spi0, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
     }
 }
 
@@ -35,12 +38,30 @@ CZC624Comms::~CZC624Comms()
     printf("~CZC624Comms()\n");
 }
 
+bool CZC624Comms::loop(uint8_t channel_id)
+{
+    if (spi_is_writable(_spi) && (time_us_64() - _last_msg_us > 1000))
+    {
+        message msg = {0};
+        msg.command = (uint8_t)CZC624Comms::spi_command_t::NoOp;
+        send_message(msg);
+    }
+
+    return (_led_state & (1 << channel_id));
+}
+
 void CZC624Comms::send_message(message msg)
 {
+    uint8_t recv[sizeof(msg)];
     if (_spi)
     {
-        uint8_t *ptr = (uint8_t*)&msg;
-        spi_write_blocking(_spi, ptr, sizeof(msg));
+        uint8_t *send_ptr = (uint8_t*)&msg;
+
+        spi_write_read_blocking(_spi, send_ptr, (uint8_t*)&recv, sizeof(msg));
+        _last_msg_us = time_us_64();
+        
+        // Whenever we send a message, we get the desired LED states for each channel in return
+        _led_state = recv[0];
     }
 }
 
@@ -150,3 +171,4 @@ bool CZC624Comms::get_major_minor_version(uint8_t *major, uint8_t *minor)
 
     return retval;
 }
+

--- a/source/zc95/core1/output/ZC624Output/CZC624Comms.h
+++ b/source/zc95/core1/output/ZC624Output/CZC624Comms.h
@@ -26,9 +26,10 @@ class CZC624Comms
             PowerDown = 3,
             
             SetFreq = 4,
-            SetPulseWitdh = 5,
+            SetPulseWidth = 5,
             SwitchOn = 6,
-            SwitchOff = 7
+            SwitchOff = 7,
+            NoOp = 8
         };
 
         enum class i2c_reg_t
@@ -70,12 +71,16 @@ class CZC624Comms
         void send_message(message msg);
         bool write_i2c_register(i2c_reg_t reg, uint8_t value);
         bool get_i2c_register(i2c_reg_t reg, uint8_t *value);
+        bool loop(uint8_t channel_id);
 
     private:
         bool get_i2c_register_range(i2c_reg_t reg, uint8_t *buffer, uint8_t size);
+        void set_led_colour(uint8_t channel, uint32_t colour);
 
         spi_inst_t *_spi;
         i2c_inst_t *_i2c;
+        uint8_t _led_state = 0;
+        uint64_t _last_msg_us = 0;
 };
 
 

--- a/source/zc95/core1/output/collar/CCollarChannel.cpp
+++ b/source/zc95/core1/output/collar/CCollarChannel.cpp
@@ -42,8 +42,8 @@ CCollarChannel::CCollarChannel(
 
     saved_settings->get_collar_config(channel_id, _collar_conf);
 
-    _inital_led_colour = LedColour::Yellow;
-    set_led_colour(_inital_led_colour);
+    _standby_led_colour = LedColour::Yellow;
+    set_led_colour(_standby_led_colour);
 }
 
 CCollarChannel::~CCollarChannel()

--- a/source/zc95/core1/routines/CRoutine.h
+++ b/source/zc95/core1/routines/CRoutine.h
@@ -281,7 +281,11 @@ class CRoutine
                     _simple_channel[channel]->channel_off();
 
                 if (_full_channel[channel] != NULL)
+                {
                     _full_channel[channel]->off();
+                    _full_channel[channel]->set_freq(DEFAULT_FREQ_HZ);
+                    _full_channel[channel]->set_pulse_width(DEFAULT_PULSE_WIDTH, DEFAULT_PULSE_WIDTH);
+                }
             }
         }
 

--- a/source/zc95/zc95.cpp
+++ b/source/zc95/zc95.cpp
@@ -149,14 +149,6 @@ void seed_random_from_rosc()
   srand(random);
 } 
 
-bool static s_led_update_timer_callback(repeating_timer_t *rt)
-{
-    static uint8_t counter = 0;
-    CLedControl *led = (CLedControl*)rt->user_data;
-    led->loop(!(counter++));
-    return true;
-}
-
 int main()
 {
     // Serial going to 3.5mm aux socket
@@ -285,9 +277,6 @@ int main()
     uint64_t last_analog_check = 0;
     display.set_battery_percentage(batteryGauge.get_battery_percentage());
 
-    repeating_timer_t led_update_timer;
-    add_repeating_timer_ms(1, s_led_update_timer_callback, &led, &led_update_timer);
-
     while (1) 
     {
         uint64_t loop_start = time_us_64();
@@ -314,6 +303,7 @@ int main()
             start = time_us_64();
             controls.process(true);   // ~215us
             ext_input->process(true); // ~215us
+            led.loop(true); // ~55u
 
             uint64_t timenow = time_us_64();
             uint8_t batt_percentage = batteryGauge.get_battery_percentage();
@@ -329,6 +319,7 @@ int main()
         }
 
         routine_output->loop();
+        led.loop();
         analogueCapture.process();
         audio.process();
 

--- a/source/zc95/zc95.cpp
+++ b/source/zc95/zc95.cpp
@@ -149,6 +149,14 @@ void seed_random_from_rosc()
   srand(random);
 } 
 
+bool static s_led_update_timer_callback(repeating_timer_t *rt)
+{
+    static uint8_t counter = 0;
+    CLedControl *led = (CLedControl*)rt->user_data;
+    led->loop(!(counter++));
+    return true;
+}
+
 int main()
 {
     // Serial going to 3.5mm aux socket
@@ -277,6 +285,9 @@ int main()
     uint64_t last_analog_check = 0;
     display.set_battery_percentage(batteryGauge.get_battery_percentage());
 
+    repeating_timer_t led_update_timer;
+    add_repeating_timer_ms(1, s_led_update_timer_callback, &led, &led_update_timer);
+
     while (1) 
     {
         uint64_t loop_start = time_us_64();
@@ -303,7 +314,6 @@ int main()
             start = time_us_64();
             controls.process(true);   // ~215us
             ext_input->process(true); // ~215us
-            led.loop(true); // ~55us    
 
             uint64_t timenow = time_us_64();
             uint8_t batt_percentage = batteryGauge.get_battery_percentage();
@@ -319,7 +329,6 @@ int main()
         }
 
         routine_output->loop();
-        led.loop();
         analogueCapture.process();
         audio.process();
 


### PR DESCRIPTION
LED output now comes from the zc624 output board via SPI regardless of pattern, so Lua scripts can show more than just solid red or solid green.
Could still use improvement at some point, but it's a step forward.

Both zc95 & zc624 firmwares need updating.

Closes #62 
