### PR TITLE
Use OK LED on zc624 & improve error reporting

### DIFF
--- a/docs/Build.md
+++ b/docs/Build.md
@@ -194,6 +194,8 @@ Before showing the confirmation screen, the box will have confirmed the EEPROM I
 EEPROM is used to store all settings that can be changed via the menus, but it does not store any uploaded Lua scripts - these are stored in flash, and can be wiped by reuploading the firmware. 
 
 ## ZC624 output module
+If the ZC624 passes its self test, the OK LED should light (which should be ~1-2 seconds after power on). If it fails, this light should flash.
+
 There is also debugging output from the ZC624 board on the serial header. Note that is at 3v3 level, and RS232 levels would damage it.
 
 Connect a 3.3v TTL serial to USB adapter to the pins labelled Tx and GND on the header, connect at 115200 baud, and power it on. 

--- a/source/zc624/COutput.cpp
+++ b/source/zc624/COutput.cpp
@@ -59,7 +59,6 @@ COutput::COutput(PIO pio, CI2cSlave *i2c_slave)
         printf("One or more chanel failed calibration, not enabling power.\n");
         _i2c_slave->set_value((uint8_t)CI2cSlave::reg::OverallStatus, CI2cSlave::status::Fault);
         gpio_put(PIN_9V_ENABLE, 0);
-        
     }
 }
 

--- a/source/zc624/config.h
+++ b/source/zc624/config.h
@@ -42,6 +42,7 @@
 
 
 #define PIN_9V_ENABLE   14
+#define PIN_OK_LED      15
 
 #define PIN_CHAN1_GATE_A 6
 #define PIN_CHAN1_GATE_B 7

--- a/source/zc95/CHwCheck.cpp
+++ b/source/zc95/CHwCheck.cpp
@@ -166,7 +166,8 @@ void CHwCheck::check_part2(CLedControl *ledControl, CControlsPortExp *controls)
     if (!error)
     {
         printf("    ZC624 status...");
-        if (!(_zc624_comms->check_zc624()))
+        _zc624_status = _zc624_comms->check_zc624();
+        if (_zc624_status)
         {
             printf("FAULT\n");
             error = true;
@@ -192,10 +193,10 @@ bool CHwCheck::audio_digipot_found()
     return false;
 }
 
-void CHwCheck::show_error_text_message(int y, std::string message)
+void CHwCheck::show_error_text_message(int *y, std::string message)
 {
-    y += 2;
-    put_text(message, 0, (y++ * 10), hagl_color(_hagl_backend, 0xFF, 0xFF, 0xFF));
+    *y += 2;
+    put_text(message, 0, ((*y)++ * 10), hagl_color(_hagl_backend, 0xFF, 0xFF, 0xFF));
 }
 
 void CHwCheck::show_error_text_missing(int y)
@@ -227,7 +228,7 @@ void CHwCheck::die(CLedControl *led_control, std::string error_message)
     halt(led_control);
 }
 
-void CHwCheck::hw_check_failed(enum Cause casue, CLedControl *ledControl, CControlsPortExp *controls)
+void CHwCheck::hw_check_failed(enum Cause cause, CLedControl *ledControl, CControlsPortExp *controls)
 {
     int y = 0;
     ledControl->set_all_led_colour(LedColour::Red);
@@ -246,36 +247,57 @@ void CHwCheck::hw_check_failed(enum Cause casue, CLedControl *ledControl, CContr
 
     put_text("Hardware check failed", (y++ * 10), 10, hagl_color(_hagl_backend, 0xFF, 0xFF, 0xFF));
 
-    switch (casue)
+    switch (cause)
     {
         case Cause::MISSING:
             show_error_text_missing(y);
             break;
 
         case Cause::BATTERY:
-            show_error_text_message(y, "Battery is flat!");
+            show_error_text_message(&y, "Battery is flat!");
             break;
 
         case Cause::ZC624_STATUS:
-            show_error_text_message(y, "ZC624 (output) fault");
+            report_zc624_fault(&y);
             break;
 
         case Cause::ZC624_VERSION:
-            show_error_text_message(y, "ZC624 version mismatch");
+            show_error_text_message(&y, "ZC624 version mismatch");
             break;
 
         case Cause::ZC624_UNKNOWN:
-            show_error_text_message(y, "Unknown ZC624 error");
+            show_error_text_message(&y, "Unknown ZC624 error");
             break;
         
         default:
-            show_error_text_message(y, "Unknown error");
+            show_error_text_message(&y, "Unknown error");
             break;
     }
 
     hagl_flush(_hagl_backend);
 
     halt(ledControl);
+}
+
+void CHwCheck::report_zc624_fault(int *y)
+{
+    std::string chan_state;
+    show_error_text_message(y, "ZC624 (output) fault");
+
+    // If the status is 0xFF, it means we couldn't read the status, so don't output what we don't know
+    if (_zc624_status != 0xFF)
+    {
+        put_text("Overall status: FAULT", 0, ((*y)++ * 10), hagl_color(_hagl_backend, 0xFF, 0xFF, 0xFF));
+        for (uint8_t chan = 1; chan <= MAX_CHANNELS; chan++)
+        {
+            if (_zc624_status & 1 << chan)
+                chan_state = "FAULT";
+            else
+                chan_state = "OK";
+
+            put_text("Channel " + std::to_string(chan) + "     : " + chan_state, 0, ((*y)++ * 10), hagl_color(_hagl_backend, 0xFF, 0xFF, 0xFF));
+        }
+    }
 }
 
 // Try and determine if running on a Pico or Pico W, based on code from 

--- a/source/zc95/CHwCheck.h
+++ b/source/zc95/CHwCheck.h
@@ -37,11 +37,12 @@ class CHwCheck
     private:
         enum Cause {UNKNOWN, MISSING, BATTERY, ZC624_UNKNOWN, ZC624_STATUS, ZC624_VERSION};
         void show_error_text_missing(int y);
-        void show_error_text_message(int y, std::string message);
+        void show_error_text_message(int *y, std::string message);
         void hw_check_failed(enum Cause casue, CLedControl *ledControl, CControlsPortExp *controls);
         void put_text(std::string text, int16_t x, int16_t y, hagl_color_t color);
         void get_battery_readings();
         void halt(CLedControl *led_control);
+        void report_zc624_fault(int *y);
 
         class device
         {
@@ -66,6 +67,7 @@ class CHwCheck
         std::list<device> _devices;
         CBatteryGauge *_batteryGauge;
         hagl_backend_t *_hagl_backend = NULL;
+        uint8_t _zc624_status = 0;
 };
 
 #endif

--- a/source/zc95/core1/output/ZC624Output/CZC624Comms.h
+++ b/source/zc95/core1/output/ZC624Output/CZC624Comms.h
@@ -61,7 +61,7 @@ class CZC624Comms
             Fault     = 0x02
         };
 
-        bool check_zc624();
+        uint8_t check_zc624();
         std::string get_version();
         bool get_major_minor_version(uint8_t *major, uint8_t *minor);
         
@@ -75,7 +75,8 @@ class CZC624Comms
 
     private:
         bool get_i2c_register_range(i2c_reg_t reg, uint8_t *buffer, uint8_t size);
-        void set_led_colour(uint8_t channel, uint32_t colour);
+        bool channel_has_fault(uint8_t channel);
+        std::string status_to_string(status s);
 
         spi_inst_t *_spi;
         i2c_inst_t *_i2c;


### PR DESCRIPTION
1. If the zc624 passes its self test, switch the OK LED on. If it fails, flash the LED.
2. If the zc624 doesn't pass its self test, show more information on the zc95 error screen which indicates which channel(s) are at fault 