### PR TITLE
Test SPI comms between main board and output board on startup

### DIFF
--- a/source/zc624/CI2cSlave.h
+++ b/source/zc624/CI2cSlave.h
@@ -30,6 +30,8 @@ class CI2cSlave
             VerStrStart    = 0x20,
             VerStrEnd      = 0x34, //  20 character string
 
+            TestVal        = 0x40,
+
             // Read/write
             // starting at 0x80
             ChannelIsolation = 0x80 // Default = true. If false, multiple channels can pulse at the same time (triphase effects)

--- a/source/zc624/CMessageProcess.cpp
+++ b/source/zc624/CMessageProcess.cpp
@@ -3,10 +3,11 @@
 #include "hardware/spi.h"
 #include <stdio.h>
 
-CMessageProcess::CMessageProcess(COutput *output)
+CMessageProcess::CMessageProcess(COutput *output, CI2cSlave *i2c_slave)
 {
     printf("CMessageProcess()\n");
     _output = output;
+    _i2c_slave = i2c_slave;
 }
 
 CMessageProcess::~CMessageProcess()
@@ -34,7 +35,7 @@ void CMessageProcess::loop()
     message msg;
 
     spi_read_blocking(SPI_PORT, _output->get_channel_led_state(), (uint8_t*)&msg, 4);
-//printf("command = %d, arg 0=%d, 1=%d, 2=%d\n", msg.command, msg.arg0, msg.arg1, msg.arg2);
+// printf("command = %d, arg 0=%d, 1=%d, 2=%d\n", msg.command, msg.arg0, msg.arg1, msg.arg2);
     switch ((command)msg.command)
     {
         case command::Pulse:
@@ -67,6 +68,11 @@ void CMessageProcess::loop()
 
         case command::NoOp:
             // Sent so we can send LED states 
+            break;
+
+        case command::SetTestVal:
+            // Used so zc95 can test that SPI comms are working (at least to some extent) on startup. It'll use i2c to read this value back.
+            _i2c_slave->set_value((uint8_t)CI2cSlave::reg::TestVal, msg.arg0);
             break;
 
         default:

--- a/source/zc624/CMessageProcess.h
+++ b/source/zc624/CMessageProcess.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include "COutput.h"
+#include "CI2cSlave.h"
 
 class CMessageProcess
 {
@@ -18,7 +19,6 @@ class CMessageProcess
 
         enum class command
         {
-            Pulse = 0,
             SetPower = 1,
             Poll = 2,
             PowerDown = 3,
@@ -27,10 +27,12 @@ class CMessageProcess
             SetPulseWidth = 5,
             SwitchOn = 6,
             SwitchOff = 7,
-            NoOp = 8
+            NoOp = 8,
+            SetTestVal = 9,
+            Pulse = 10
         };
     
-        CMessageProcess(COutput *output);
+        CMessageProcess(COutput *output, CI2cSlave *i2c_slave);
         ~CMessageProcess();
         void init();
 
@@ -45,6 +47,8 @@ class CMessageProcess
         void on(message msg);
         void off(message msg);
         void power_down(message msg);
+
+        CI2cSlave *_i2c_slave;
 };
 
 #endif

--- a/source/zc624/OutputZc.cpp
+++ b/source/zc624/OutputZc.cpp
@@ -58,7 +58,7 @@ int main()
     COutput output = COutput(pio0, i2c_slave);
 
     // Comms to main board
-    CMessageProcess spi_message_process = CMessageProcess(&output);
+    CMessageProcess spi_message_process = CMessageProcess(&output, i2c_slave);
     spi_message_process.init();
     uint64_t loop_start = time_us_64();
     uint64_t readable=0;

--- a/source/zc624/config.h
+++ b/source/zc624/config.h
@@ -35,7 +35,7 @@
 
 
 #define DEVICE_TYPE   624
-#define VERSION_MAJOR   1
+#define VERSION_MAJOR   2
 #define VERSION_MINOR   0
 
 

--- a/source/zc95/CHwCheck.h
+++ b/source/zc95/CHwCheck.h
@@ -35,7 +35,7 @@ class CHwCheck
         void set_display(CDisplay *display);
 
     private:
-        enum Cause {UNKNOWN, MISSING, BATTERY, ZC624_UNKNOWN, ZC624_STATUS, ZC624_VERSION};
+        enum Cause {UNKNOWN, MISSING, BATTERY, ZC624_UNKNOWN, ZC624_STATUS, ZC624_VERSION, ZC624_NO_SPI};
         void show_error_text_missing(int y);
         void show_error_text_message(int *y, std::string message);
         void hw_check_failed(enum Cause casue, CLedControl *ledControl, CControlsPortExp *controls);

--- a/source/zc95/config.h
+++ b/source/zc95/config.h
@@ -16,7 +16,7 @@
 #define I2C_PORT i2c0  // main i2c bus for port expanders + eeprom
 
 // Set expected version for zc624 output module
-#define ZC624_REQUIRED_MAJOR_VERION 1
+#define ZC624_REQUIRED_MAJOR_VERION 2
 #define ZC624_MIN_MINOR_VERION      0
 
 // Versions for the GetVersion/VersionDetails message, but that's not used by anything yet
@@ -38,8 +38,8 @@
 #define PIN_FP_INT1       11 // front panel interrupt 1 (U1) - 4x channel rot encoders
 #define PIN_FP_INT2        6 // front panel interrupt 2 (U2) - 5x rot encoder buttons & 1x adjust rot encoder (+ 1x unused line)
 
-
 // Output board SPI
+#define ZC624_SPI_PORT            spi1
 #define PIN_OUTPUT_BOARD_SPI_RX   12
 #define PIN_OUTPUT_BOARD_SPI_SCK  14
 #define PIN_OUTPUT_BOARD_SPI_TX   15
@@ -61,10 +61,7 @@
 #define MAX_POWER_LEVEL 1000
 #define MAX_CHANNELS 4
 
-
-// SPI Defines
-// We are going to use SPI 0, and allocate it to the following GPIO pins
-// Pins can be changed, see the GPIO function select table in the datasheet for information on GPIO assignments
+// SPI Defines for display
 #define SPI_PORT spi0
 #define PIN_MISO 16
 #define PIN_CS   17

--- a/source/zc95/core1/output/CChannelConfig.h
+++ b/source/zc95/core1/output/CChannelConfig.h
@@ -33,7 +33,7 @@ class CChannelConfig
         CPowerLevelControl *_power_level_control;
         CCollarComms _collar_comms = CCollarComms(PIN_433TX); // 433MHz transmitter for collars
     
-        CZC624Comms _zc614_comms = CZC624Comms(spi1, I2C_PORT);
+        CZC624Comms _zc614_comms = CZC624Comms(ZC624_SPI_PORT, I2C_PORT);
 };
 
 #endif  

--- a/source/zc95/core1/output/ZC624Output/CZC624Comms.h
+++ b/source/zc95/core1/output/ZC624Output/CZC624Comms.h
@@ -20,7 +20,6 @@ class CZC624Comms
 
         enum class spi_command_t
         {
-            Pulse = 0,
             SetPower = 1,
             Poll = 2,
             PowerDown = 3,
@@ -29,7 +28,9 @@ class CZC624Comms
             SetPulseWidth = 5,
             SwitchOn = 6,
             SwitchOff = 7,
-            NoOp = 8
+            NoOp = 8,
+            SetTestVal = 9,
+            Pulse = 10
         };
 
         enum class i2c_reg_t
@@ -49,6 +50,8 @@ class CZC624Comms
             VerStrStart      = 0x20,
             VerStrEnd        = 0x34, //  20 character string
 
+            TestVal          = 0x40,
+
             // Read/write
             // starting at 0x80
             ChannelIsolation = 0x80
@@ -64,6 +67,7 @@ class CZC624Comms
         uint8_t check_zc624();
         std::string get_version();
         bool get_major_minor_version(uint8_t *major, uint8_t *minor);
+        bool spi_has_comms_fault();
         
         CZC624Comms(spi_inst_t *spi, i2c_inst_t *i2c);
         ~CZC624Comms();
@@ -77,6 +81,7 @@ class CZC624Comms
         bool get_i2c_register_range(i2c_reg_t reg, uint8_t *buffer, uint8_t size);
         bool channel_has_fault(uint8_t channel);
         std::string status_to_string(status s);
+        bool test_spi_comms(uint8_t test_val);
 
         spi_inst_t *_spi;
         i2c_inst_t *_i2c;


### PR DESCRIPTION
Addresses #68

Do a basic test that SPI comms between the main board and zc624 output board are working on startup.
If not, show error screen.
