### PR TITLE
fix issue where large script would casue a crash on upload

### DIFF
--- a/source/zc95/CLuaStorage.h
+++ b/source/zc95/CLuaStorage.h
@@ -29,7 +29,7 @@ class CLuaStorage
         };
 
         static size_t get_lua_flash_size(uint8_t index);
-        bool store_script(uint8_t index, const char* lua_script, size_t buffer_size);
+        bool store_script_section(uint8_t script_index, uint8_t section, const char* lua_script_fragment, size_t buffer_size);
         bool delete_script_at_index(uint8_t index);
 
         static const char* get_script_at_index(uint8_t index);
@@ -39,6 +39,7 @@ class CLuaStorage
 
     private:
         static uint32_t get_flash_offset(uint8_t script_index);
+        bool is_script_index_valid(uint8_t index);
 };
 
 #endif

--- a/source/zc95/CMakeLists.txt
+++ b/source/zc95/CMakeLists.txt
@@ -213,14 +213,14 @@ target_compile_definitions(zc95 PRIVATE
   HAGL_HAL_USE_DMA
   HAGL_HAL_DEBUG
   MIPI_DISPLAY_ST7735
-  PICO_STACK_SIZE=12288
+  PICO_STACK_SIZE=8192
   PICO_CORE1_STACK_SIZE=0 # stack is malloc'd
   PICO_USE_STACK_GUARDS   # would rather die instantly on stack overflow, than get weird, hard to debug, errors
   
   # For Lua. If a Lua script consumes all the memory, Lua can handle that and give an OOM error, which is better 
   # than crashing with a Panic. Ideally Lua would use a seperate alloc function that didn't panic, whilst everything
   # else did. Not quite sure how to manage that yet; multicore/malloc mutex complicates things.
-  PICO_MALLOC_PANIC=0     
+  PICO_MALLOC_PANIC=0
 )
 
 target_compile_definitions(zc95 PRIVATE

--- a/source/zc95/RemoteAccess/CLuaLoad.cpp
+++ b/source/zc95/RemoteAccess/CLuaLoad.cpp
@@ -139,8 +139,8 @@ bool CLuaLoad::process(StaticJsonDocument<MAX_WS_MESSAGE_SIZE> *doc)
     {
         if (_lua_buffer)
         {
-            printf("_lua_buffer_\n");
-            puts((char*)_lua_buffer);
+           // printf("_lua_buffer_\n");
+           // puts((char*)_lua_buffer);
 
             CLuaRoutine lua = CLuaRoutine((const char*)_lua_buffer);
             bool ret = lua.is_script_valid();

--- a/source/zc95/RemoteAccess/CLuaLoad.cpp
+++ b/source/zc95/RemoteAccess/CLuaLoad.cpp
@@ -17,11 +17,18 @@
  */
 
 /* Deal with sanity checking and saving Lua scripts being sent over
- * a websocket connection into flash. 
+ * a websocket/serial connection into flash. 
  * Processes messages:
  *  - LuaStart
  *  - LuaLine
  *  - LuaEnd
+ *
+ * Received scripts are written to flash in LUA_UPLOAD_BUFFER_SIZE (4096) byte 
+ * blocks. The first byte of the script in flash is initially set to 0/NULL, so
+ * that if either something goes wrong during the upload, or the script is not
+ * valid, it won't show up on the patterns menu.
+ * If all is good, this is changed to a newline, which as the first byte of a
+ * script should have no impact. 
  */
 
 #include "CLuaLoad.h"
@@ -38,6 +45,11 @@ CLuaLoad::CLuaLoad(
     _send = send_function;
     _send_ack = send_ack_func;
     _lua_storage = new CLuaStorage();
+    _lua_buffer = (uint8_t*)calloc(LUA_UPLOAD_BUFFER_SIZE, sizeof(uint8_t));
+    if (_lua_buffer == NULL)
+    {
+        panic("CLuaLoad::CLuaLoad(): ERROR - calloc returned NULL. Out of memory.");
+    }
 }
 
 CLuaLoad::~CLuaLoad()
@@ -47,14 +59,25 @@ CLuaLoad::~CLuaLoad()
     {
         free(_lua_buffer);
         _lua_buffer = NULL;
-        _lua_buffer_size = 0;
-        _lua_buffer_postion = 0;
     }
 
     if (_lua_storage)
     {
         delete _lua_storage;
         _lua_storage = NULL;
+    }
+}
+
+void CLuaLoad::reset()
+{
+    printf("CLuaLoad: reset\n");
+    _lua_slot_size = 0;
+    _lua_slot_section = 0;
+    _lua_buffer_postion = 0;
+
+    if (_lua_buffer)
+    {
+        memset(_lua_buffer, 0, LUA_UPLOAD_BUFFER_SIZE);
     }
 }
 
@@ -67,16 +90,12 @@ bool CLuaLoad::process(StaticJsonDocument<MAX_WS_MESSAGE_SIZE> *doc)
     bool retval = false;
     std::string errorMessage = "";
 
+    if (_lua_buffer == NULL)
+        return true;
+
     if (msgType == "LuaStart")
     {
-        if (_lua_buffer)
-        {
-            free(_lua_buffer);
-            _lua_buffer = NULL;
-            _lua_buffer_size = 0;
-            _lua_buffer_postion = 0;
-        }
-
+        reset();
         _index = (*doc)["Index"];
 
         if (_index >= lua_script_count())
@@ -95,66 +114,107 @@ bool CLuaLoad::process(StaticJsonDocument<MAX_WS_MESSAGE_SIZE> *doc)
         {
             int flash_size = _lua_storage->get_lua_flash_size(_index);
             printf("CLuaLoad: Need %d bytes for lua script index %d\n", flash_size, _index);
-
-            if (flash_size != 0)
+            if (flash_size <= 0)
             {
-                _lua_buffer_size = flash_size;
-                _lua_buffer = (uint8_t*)calloc(_lua_buffer_size, sizeof(uint8_t));
-                _lua_buffer_postion = 0;
-            }
-
-            if (_lua_buffer == NULL)
-            {
-                printf("CLuaLoad: NULL lua buffer. Invalid index or out of memory?\n");
+                printf("CLuaLoad: Error - invalid flash size: %d\n", flash_size);
                 retval = true;
             }
+
+            _lua_slot_size = flash_size;
+            _lua_buffer_postion = 1; // First byte of script slot will be null to start with. If the script uploads ok and doesn't error out, change to ' ' to enable script
         }
     }
     else if (msgType == "LuaLine")
     {
-        if (_lua_buffer)
+        if (_index >= 0)
         {
             std::string text = (*doc)["Text"];
             text += "\n";
-            if (_lua_buffer_postion + text.length() + 4 >= _lua_buffer_size)
+            const char *text_c = text.c_str();
+
+            size_t i = 0;
+            while (*(text_c+i))
             {
-                printf("CLuaLoad: Buffer full! Lua script too large\n");
-                errorMessage = "Script too large";
-                retval = true;
+                if (_lua_buffer_postion >= LUA_UPLOAD_BUFFER_SIZE)
+                {
+                    // write section to flash
+                    _routines_updated = true;
+                    bool store_result = _lua_storage->store_script_section(_index, _lua_slot_section, (const char*)_lua_buffer, LUA_UPLOAD_BUFFER_SIZE);
+                    _lua_buffer_postion = 0;
+                    memset(_lua_buffer, 0, LUA_UPLOAD_BUFFER_SIZE);
+                    if (!store_result)
+                    {
+                        printf("CLuaLoad: error storing script section %d\n", _lua_slot_section);
+                        errorMessage = "Error storing script";
+                        retval = true;
+                        break;
+                    }
+                    _lua_slot_section++;
+
+                    if (_lua_slot_section >= (_lua_slot_size / LUA_UPLOAD_BUFFER_SIZE))
+                    {
+                        printf("CLuaLoad: script too large. New _lua_slot_section=%d, _lua_slot_size=%d, buffer size=%d\n", 
+                            _lua_slot_section, _lua_slot_size, LUA_UPLOAD_BUFFER_SIZE);
+                        errorMessage = "Script too large";
+                        retval = true;
+                        break;
+                    }
+                }
+
+                _lua_buffer[_lua_buffer_postion++] = *(text_c+i);
+                i++;
             }
-            else
-            {
-                memcpy(_lua_buffer + _lua_buffer_postion, text.c_str(), text.length());
-                _lua_buffer_postion += text.length();
-            }
-        } 
+        }
         else
         {
-            // NULL _lua_buffer
             printf("CLuaLoad: LuaLine without valid LuaStart\n");
             retval = true;
         }
     }
     else if (msgType == "LuaEnd")
     {
-        if (_lua_buffer)
+        if (_index >= 0)
         {
-           // printf("_lua_buffer_\n");
-           // puts((char*)_lua_buffer);
+            // Write what's still in lua_buffer to flash
+            bool store_result = _lua_storage->store_script_section(_index, _lua_slot_section, (const char*)_lua_buffer, LUA_UPLOAD_BUFFER_SIZE);
+            if (!store_result)
+            {
+                printf("CLuaLoad: error storing script section %d\n", _lua_slot_section);
+                _send_ack("ERROR", msgId, "Failed to store script");
+                reset();
+                return true;
+            }
 
-            CLuaRoutine lua = CLuaRoutine((const char*)_lua_buffer);
+            const char *lua_script = (const char *)(lua_scripts[_index].start);
+            lua_script++; // Skip over inital null
+            //printf("lua_script:\n");
+            //puts(lua_script);
+
+            CLuaRoutine lua = CLuaRoutine(lua_script);
             bool ret = lua.is_script_valid();
             if (ret)
             {
                 printf("CLuaLoad::process() script ok\n");
-                _lua_storage->store_script(_index, (const char*)_lua_buffer, _lua_buffer_size);
-                _routines_updated = true;
+
+                // Script is good (or at least not horribly broken), now remove that inital null so it will get processed at startup and show on the patterns list
+                memcpy(_lua_buffer, (const char *)(lua_scripts[_index].start), LUA_UPLOAD_BUFFER_SIZE);
+                _lua_buffer[0] = '\n';
+                bool store_result = _lua_storage->store_script_section(_index, 0, (const char*)_lua_buffer, LUA_UPLOAD_BUFFER_SIZE);
+                if (!store_result)
+                {
+                    // I don't think this should be possible
+                    printf("CLuaLoad::process(): failed to clear NULL at script of script\n");
+                    _send_ack("ERROR", msgId, "Internal error");
+                    reset();
+                    return true;                    
+                }
             }
             else
             {
                 std::string lua_error = lua.get_last_lua_error();
                 printf("CLuaLoad::process() bad script!\n\t%s\n", lua_error.c_str());
                 _send_ack("ERROR", msgId, "Invalid script: " + lua_error);
+                reset();
                 return true;
             }
         }
@@ -169,7 +229,10 @@ bool CLuaLoad::process(StaticJsonDocument<MAX_WS_MESSAGE_SIZE> *doc)
     }
 
     if (retval)
+    {
         send_ack("ERROR", msgId, errorMessage);
+        reset();
+    }
     else
         send_ack("OK", msgId);
 

--- a/source/zc95/RemoteAccess/CLuaLoad.h
+++ b/source/zc95/RemoteAccess/CLuaLoad.h
@@ -23,11 +23,13 @@ class CLuaLoad
         std::function<void(std::string)> _send;
         std::function<void(std::string result, int msg_count, std::string error)> _send_ack;
         void send_ack(std::string result, int msg_count, std::string error = "");
+        void reset();
 
         uint8_t *_lua_buffer = NULL;
-        size_t _lua_buffer_size = 0;
+        size_t _lua_slot_size = 0;
+        uint8_t _lua_slot_section = 0;
         uint _lua_buffer_postion = 0;
-        int _index = 0;
+        int _index = -1;
         CLuaStorage *_lua_storage;
         bool _routines_updated = false;
 };

--- a/source/zc95/RemoteAccess/CMessageProcessor.cpp
+++ b/source/zc95/RemoteAccess/CMessageProcessor.cpp
@@ -276,7 +276,7 @@ void CMessageProcessor::loop()
 void CMessageProcessor::send_lua_scripts(StaticJsonDocument<MAX_WS_MESSAGE_SIZE> *doc)
 {
     int msg_count = (*doc)["MsgId"];
-    StaticJsonDocument<1000> response_message;
+    DynamicJsonDocument response_message(1000);
 
     response_message["Type"] = "LuaScripts";
     response_message["MsgId"] = msg_count;
@@ -317,7 +317,7 @@ void CMessageProcessor::delete_lua_script(StaticJsonDocument<MAX_WS_MESSAGE_SIZE
 void CMessageProcessor::send_pattern_list(StaticJsonDocument<MAX_WS_MESSAGE_SIZE> *doc)
 {
     int msg_count = (*doc)["MsgId"];
-    StaticJsonDocument<2000> response_message;
+    DynamicJsonDocument response_message(2000);
 
     response_message["Type"] = "PatternList";
     response_message["MsgId"] = msg_count;
@@ -355,7 +355,8 @@ void CMessageProcessor::send_pattern_detail(StaticJsonDocument<MAX_WS_MESSAGE_SI
     int msg_count = (*doc)["MsgId"];
     int id = (*doc)["Id"];
 
-    StaticJsonDocument<2500> response_message;
+    DynamicJsonDocument response_message(2500);
+
     response_message["Type"] = "PatternDetail";
     response_message["MsgId"] = msg_count;
 

--- a/source/zc95/RemoteAccess/CMessageProcessor.cpp
+++ b/source/zc95/RemoteAccess/CMessageProcessor.cpp
@@ -194,7 +194,7 @@ void CMessageProcessor::loop()
 {
     if (_pending_message)
     {
-        printf("CMessageProcessor::loop() processing pending message\n");
+        // printf("CMessageProcessor::loop() processing pending message\n");
 
         StaticJsonDocument<MAX_WS_MESSAGE_SIZE> doc;
         DeserializationError error = deserializeJson(doc, _pending_message_buffer);

--- a/source/zc95/RemoteAccess/CRoutineRun.cpp
+++ b/source/zc95/RemoteAccess/CRoutineRun.cpp
@@ -202,7 +202,7 @@ void CRoutineRun::send_lua_script_error_message()
 
 void CRoutineRun::send_power_status_update()
 {
-    StaticJsonDocument<1000> status_message;
+    DynamicJsonDocument status_message(1000);
 
     status_message["Type"] = "PowerStatus";
     status_message["MsgId"] = -1;

--- a/source/zc95/config.h
+++ b/source/zc95/config.h
@@ -86,3 +86,5 @@
 #define ACC_PORT_UART uart1
 
 #define SERIAL_TX_QUEUE_SIZE 2000 // only used when in remote access/serial mode
+
+#define LUA_UPLOAD_BUFFER_SIZE  4096 // Will probably break if not a multiple of 4096, likely also depends on the script slot sizes in flash (see LuaScripts/LuaScripts.S)


### PR DESCRIPTION
See #81 & #91 

* Reduces stack size of core0, and stops allocating large objects on the stack when generating messages to send over wifi/serial. See #91 for explanation.
* No longer stores whole received script in memory when uploading - it is now written to flash in 4k blocks during upload
