### PR TITLE
fix issue where shock collars are using potentially stale configuration

### DIFF
--- a/source/zc95/core1/output/collar/CCollarChannel.cpp
+++ b/source/zc95/core1/output/collar/CCollarChannel.cpp
@@ -33,14 +33,13 @@ CCollarChannel::CCollarChannel(
     CSimpleOutputChannel(saved_settings, power_level_control, channel_id)
 {
     printf("CCollarChannel(%d)\n", channel_id);
+    _saved_settings = saved_settings;
     _comms = comms;
     _current_status = collar_status::OFF;
     _last_tx_time_us = 0;
     _led_off_time = 0;
     _channel_id = channel_id;
     _collar_level = 0;
-
-    saved_settings->get_collar_config(channel_id, _collar_conf);
 
     _standby_led_colour = LedColour::Yellow;
     set_led_colour(_standby_led_colour);
@@ -135,6 +134,10 @@ void CCollarChannel::transmit (uint8_t power)
     if (get_time_us() -_last_tx_time_us < (100 * 1000))
         return;
 
-    _comms->transmit(_collar_conf.id, (CCollarComms::collar_channel)_collar_conf.channel, (CCollarComms::collar_mode)_collar_conf.mode, _collar_level);
-    _last_tx_time_us = get_time_us();
+    CSavedSettings::collar_config collar_conf;
+    if (_saved_settings->get_collar_config(_channel_id, collar_conf))
+    {
+        _comms->transmit(collar_conf.id, (CCollarComms::collar_channel)collar_conf.channel, (CCollarComms::collar_mode)collar_conf.mode, _collar_level);
+        _last_tx_time_us = get_time_us();
+    }
 }

--- a/source/zc95/core1/output/collar/CCollarChannel.h
+++ b/source/zc95/core1/output/collar/CCollarChannel.h
@@ -26,7 +26,7 @@ class CCollarChannel : public CSimpleOutputChannel
     void set_collar_level_from_power(int16_t power);
     void transmit (uint8_t power);
     CCollarComms *_comms;
-    struct CSavedSettings::collar_config _collar_conf;
+    CSavedSettings* _saved_settings;
 
     uint8_t _channel_id;
     uint64_t _last_tx_time_us;


### PR DESCRIPTION
Shock collars would use configuration loaded when channel initialised, which may have since changed via config menu, see #110 