### PR TITLE
Use rotary encoder to move though menus

### DIFF
--- a/source/zc95/display/CMenuRoutineSelection.cpp
+++ b/source/zc95/display/CMenuRoutineSelection.cpp
@@ -119,6 +119,17 @@ void CMenuRoutineSelection::adjust_rotary_encoder_change(int8_t change)
 {
     if (_submenu_active)
         _submenu_active->adjust_rotary_encoder_change(change);
+    else
+    {
+        if (change >= 1)
+        {
+            _routine_display_list->down();
+        }
+        else if (change <= -1)
+        {
+            _routine_display_list->up();
+        }
+    }
 }
 
 void CMenuRoutineSelection::draw()

--- a/source/zc95/display/config/CMenuSettings.cpp
+++ b/source/zc95/display/config/CMenuSettings.cpp
@@ -151,6 +151,17 @@ void CMenuSettings::adjust_rotary_encoder_change(int8_t change)
 {
     if (_submenu_active)
         _submenu_active->adjust_rotary_encoder_change(change);
+    else
+    {
+        if (change >= 1)
+        {
+            _settings_list->down();
+        }
+        else if (change <= -1)
+        {
+            _settings_list->up();
+        }
+    }
 }
 
  void CMenuSettings::draw()

--- a/source/zc95/display/config/remote_access/CMenuRemoteAccess.cpp
+++ b/source/zc95/display/config/remote_access/CMenuRemoteAccess.cpp
@@ -141,6 +141,17 @@ void CMenuRemoteAccess::adjust_rotary_encoder_change(int8_t change)
 {
     if (_submenu_active)
         _submenu_active->adjust_rotary_encoder_change(change);
+    else
+    {
+        if (change >= 1)
+        {
+            _options_list->down();
+        }
+        else if (change <= -1)
+        {
+            _options_list->up();
+        }
+    }
 }
 
  void CMenuRemoteAccess::draw()


### PR DESCRIPTION
With an increasing list of patterns, using the up/down buttons to move through them can get a bit tedious. Update to allow the adjust dial to be used for this as well as the buttons.