### PR TITLE
Allow rotary encoder button use; enable more menus

### DIFF
--- a/source/zc95/ECButtons.h
+++ b/source/zc95/ECButtons.h
@@ -7,7 +7,8 @@
         A = 0,     // Top left
         B = 1,     // Bottom left
         C = 2,     // Top right
-        D = 3      // Bottom right
+        D = 3,     // Bottom right
+        ROT = 5    // Rotary encoder button
       };
 
 #endif

--- a/source/zc95/FrontPanel/CFrontPanelV01.cpp
+++ b/source/zc95/FrontPanel/CFrontPanelV01.cpp
@@ -19,7 +19,7 @@ CFrontPanelV01::CFrontPanelV01(CSavedSettings *saved_settings, CMainBoardPortExp
     memset(_power_level, 0, sizeof(_power_level));
     _last_port_exp_read = 0;
     _adjust_value = 0;
-    _last_rot_button_state = false;
+    _last_rot_button_state = true;
     
     // The very first time the ADC is read, the first channel seems to have an invalid value. So read it now, 
     // so when it's read next time as usual, it'll return something sensible.

--- a/source/zc95/FrontPanel/CFrontPanelV01.h
+++ b/source/zc95/FrontPanel/CFrontPanelV01.h
@@ -23,6 +23,8 @@ class CFrontPanelV01 : public CFrontPanel
         uint8_t _last_port_exp_read;
         int16_t _power_level[MAX_CHANNELS];
         CRotEnc _rot_encoder;
+        bool _last_rot_button_state;
+        uint64_t _last_rot_button_state_change;
         int16_t _adjust_value;
         volatile bool _interrupt;
 

--- a/source/zc95/display/CDisplayMessage.cpp
+++ b/source/zc95/display/CDisplayMessage.cpp
@@ -66,6 +66,9 @@ void CDisplayMessage::button_pressed(Button button)
 
             case Button::D:
                 break;
+
+            case Button::ROT:
+                break;
         }
     }
 }

--- a/source/zc95/display/CMenuRoutineSelection.cpp
+++ b/source/zc95/display/CMenuRoutineSelection.cpp
@@ -89,7 +89,7 @@ void CMenuRoutineSelection::button_pressed(Button button)
     }
     else
         {
-        if (button == Button::A) // Select
+        if (button == Button::A || button == Button::ROT ) // Select
         {
             uint8_t routine_id = _routine_display_list->get_current_selection_id();
             CRoutines::Routine routine = _routines[routine_id];

--- a/source/zc95/display/config/CMenuSettings.cpp
+++ b/source/zc95/display/config/CMenuSettings.cpp
@@ -85,6 +85,7 @@ void CMenuSettings::button_pressed(Button button)
         switch (button)
         {
             case Button::A: // "Select"
+            case Button::ROT:
                 _last_selection = _settings_list->get_current_selection();
                 show_selected_setting();
                 break;

--- a/source/zc95/display/config/bluetooth_peripherals/CMenuBluetoothScan.cpp
+++ b/source/zc95/display/config/bluetooth_peripherals/CMenuBluetoothScan.cpp
@@ -58,6 +58,7 @@ void CMenuBluetoothScan::button_pressed(Button button)
         switch (button)
         {
             case Button::A: // "Select"
+            case Button::ROT:
                 if (_options_list->count() > 0)
                 {
                     _last_selection = -1;
@@ -87,6 +88,17 @@ void CMenuBluetoothScan::adjust_rotary_encoder_change(int8_t change)
 {
     if (_submenu_active)
         _submenu_active->adjust_rotary_encoder_change(change);
+    else
+    {
+        if (change >= 1)
+        {
+            _options_list->down();
+        }
+        else if (change <= 1)
+        {
+            _options_list->up();
+        }
+    }
 }
 
  void CMenuBluetoothScan::draw()

--- a/source/zc95/display/config/bluetooth_peripherals/CMenuBluetoothTest.cpp
+++ b/source/zc95/display/config/bluetooth_peripherals/CMenuBluetoothTest.cpp
@@ -70,6 +70,9 @@ void CMenuBluetoothTest::button_pressed(Button button)
 
             case Button::D:
                 break;
+
+            case Button::ROT:
+                break;
         }
     }
 }

--- a/source/zc95/display/config/channel_config/CMenuCollarConfig.cpp
+++ b/source/zc95/display/config/channel_config/CMenuCollarConfig.cpp
@@ -51,6 +51,7 @@ void CMenuCollarConfig::button_pressed(Button button)
         switch (button)
         {
             case Button::A: // "Select"
+            case Button::ROT:
                 set_active_menu(new CMenuCollarConfigSelected(_display, _buttons, _saved_settings, _collar_list->get_current_selection(), _routine_output));
                 break;
 
@@ -75,6 +76,17 @@ void CMenuCollarConfig::adjust_rotary_encoder_change(int8_t change)
     if (_submenu_active)
     {
         _submenu_active->adjust_rotary_encoder_change(change);
+    }
+    else
+    {
+        if (change>=1)
+        {
+            _collar_list->down();
+        }
+        else if (change<=1)
+        {
+            _collar_list->up();
+        }
     }
 }
 

--- a/source/zc95/display/config/channel_config/CMenuCollarConfigSelected.cpp
+++ b/source/zc95/display/config/channel_config/CMenuCollarConfigSelected.cpp
@@ -57,6 +57,7 @@ void CMenuCollarConfigSelected::button_pressed(Button button)
         switch (button)
         {
             case Button::A: // Regenerate / toggle / test 
+            case Button::ROT:
                 button_a_pressed();
                 break;
 
@@ -116,6 +117,19 @@ void CMenuCollarConfigSelected::adjust_rotary_encoder_change(int8_t change)
     if (_submenu_active)
     {
         _submenu_active->adjust_rotary_encoder_change(change);
+    }
+    else
+    {
+        if (change >= 1)
+        {
+            _options_list->down();
+            set_button_a_text();
+        }
+        else if (change<=1)
+        {
+            _options_list->up();
+            set_button_a_text();
+        }
     }
 }
 

--- a/source/zc95/display/config/display_options/CMenuSettingDisplayOptions.cpp
+++ b/source/zc95/display/config/display_options/CMenuSettingDisplayOptions.cpp
@@ -61,6 +61,7 @@ void CMenuSettingDisplayOptions::button_pressed(Button button)
         switch (button)
         {
             case Button::A: // "Select"
+            case Button::ROT:
                 _last_selection = _settings_list->get_current_selection();
                 show_selected_setting();
                 break;
@@ -103,6 +104,18 @@ void CMenuSettingDisplayOptions::adjust_rotary_encoder_change(int8_t change)
 {
     if (_submenu_active)
         _submenu_active->adjust_rotary_encoder_change(change);
+    else
+    {
+        if (change >= 1)
+        {
+            _settings_list->down();
+        }
+        else if (change <= 1)
+        {
+            _settings_list->up();
+        }
+
+    }
 }
 
  void CMenuSettingDisplayOptions::draw()

--- a/source/zc95/display/config/remote_access/CMenuApMode.cpp
+++ b/source/zc95/display/config/remote_access/CMenuApMode.cpp
@@ -74,6 +74,9 @@ void CMenuApMode::button_pressed(Button button)
 
             case Button::D:
                 break;
+
+            case Button::ROT:
+                break;
         }
     }
 }

--- a/source/zc95/display/config/remote_access/CMenuRemoteAccess.cpp
+++ b/source/zc95/display/config/remote_access/CMenuRemoteAccess.cpp
@@ -76,6 +76,7 @@ void CMenuRemoteAccess::button_pressed(Button button)
         switch (button)
         {
             case Button::A: // "Select"
+            case Button::ROT:
                 _last_selection = _options_list->get_current_selection();
                 show_selected_setting();
                 break;

--- a/source/zc95/display/config/remote_access/CMenuRemoteAccessBLE.cpp
+++ b/source/zc95/display/config/remote_access/CMenuRemoteAccessBLE.cpp
@@ -86,6 +86,9 @@ void CMenuRemoteAccessBLE::button_pressed(Button button)
 
             case Button::D: // "Down"
                 break;
+
+            case Button::ROT:
+                break;
         }
     }
 }

--- a/source/zc95/display/config/remote_access/CMenuRemoteAccessConnectWifi.cpp
+++ b/source/zc95/display/config/remote_access/CMenuRemoteAccessConnectWifi.cpp
@@ -85,6 +85,9 @@ void CMenuRemoteAccessConnectWifi::button_pressed(Button button)
 
             case Button::D: // "Down"
                 break;
+
+            case Button::ROT:
+                break;
         }
     }
 }

--- a/source/zc95/display/config/remote_access/CMenuRemoteAccessSerial.cpp
+++ b/source/zc95/display/config/remote_access/CMenuRemoteAccessSerial.cpp
@@ -96,6 +96,9 @@ void CMenuRemoteAccessSerial::button_pressed(Button button)
 
             case Button::D: // "Down"
                 break;
+
+            case Button::ROT:
+                break;
         }
     }
 }

--- a/source/zc95/zc95.cpp
+++ b/source/zc95/zc95.cpp
@@ -125,6 +125,7 @@ void process_front_panel_input(CMainBoardPortExp *port_expander, CMenu *current_
     check_button(current_menu, Button::B);
     check_button(current_menu, Button::C);
     check_button(current_menu, Button::D);
+    check_button(current_menu, Button::ROT);
 }
 
 void update_power_levels_from_front_panel(CRoutineOutput *routine_output)


### PR DESCRIPTION
I only tested this with a V2 front panel. I think the V1 version should work, but have no way to validate this.