### PR TITLE
Add dockerfile to build firmware

### DIFF
--- a/docs/SourceBuildNotes.md
+++ b/docs/SourceBuildNotes.md
@@ -1,16 +1,30 @@
-# Building source
+# Building
+
+## Docker
+If you just want to build the current dev release, the quickest and easiest way to compile the firmware is to use the docker image ([source](../misc/Docker/)).
+
+Steps to build, adjust paths as required:
+```
+cd /data
+git clone https://github.com/CrashOverride85/zc95.git --recurse-submodules
+docker run -v /data/zc95:/src --rm ghcr.io/crashoverride85/zc95-build:1.0.0
+```
+All going well, complied firmware images should appear in /data/zc95/source/CompiledUF2/
+
+
+## Local setup
 
 Quick start building notes for Linux, tested on a fresh install of Debian Bookworm, but should be very similar for any Debian derived distro.
 For other environments, see the [pico getting started guide][gs].
 
 This is the bare minimum to get to the point where you can build a binary to copy to the Pico.
 
-## Install build tools
+### Install build tools
 ```
 apt-get install git cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential libstdc++-arm-none-eabi-newlib python3 python3-pycryptodome
 ```
 
-## Setup pico-sdk
+### Setup pico-sdk
 ```
 git clone https://github.com/raspberrypi/pico-sdk.git
 cd pico-sdk
@@ -19,7 +33,7 @@ export PICO_SDK_PATH=`pwd`
 cd ..
 ```
 
-## Get zc95 source & build
+### Get zc95 source & build
 ```
 git clone https://github.com/CrashOverride85/zc95.git --recursive
 cd zc95/source/zc95/
@@ -34,7 +48,7 @@ This should result in the two pico binaries being built that can be copied to th
 * zc95/source/zc95/zc95.uf2 - for main board
 * zc95/source/zc624/OutputZc.uf2 - for output board
 
-# Debugging
+## Debugging
 For small fixes/changes/tweaks the above is fine, but requires manually copying to Pico via USB, and doesn't allow for debugging, so very quickly gets tedious for larger changes.
 
 The pico-sdk integrates really well with Visual Studio Code & an SWD debugger, allowing single keypress build & upload, along with setting breakpoints, stepping through code, etc., so that would be my recommendation for a development environment. 
@@ -47,7 +61,7 @@ It's probably worth noting that the code is using both cores, so bare that in mi
 [gs]: https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf
 [pp]: https://www.raspberrypi.com/products/debug-probe/
 
-# BTStack patch
+## BTStack patch
 In order to get one of the bluetooth remotes to work (#7 in [the bluetooth notes](./Bluetooth.md), and potentially later ones), in `pico-sdk/lib/btstack/src/ble/sm.c` I needed to comment this out:
 ```
         default:

--- a/docs/SourceBuildNotes.md
+++ b/docs/SourceBuildNotes.md
@@ -3,10 +3,10 @@
 ## Docker
 If you just want to build the current dev release, the quickest and easiest way to compile the firmware is to use the docker image ([source](../misc/Docker/)).
 
-Steps to build, adjust paths as required:
+Steps to build the dev branch, adjust paths as required:
 ```
 cd /data
-git clone https://github.com/CrashOverride85/zc95.git --recurse-submodules
+git clone -b dev https://github.com/CrashOverride85/zc95.git --recurse-submodules
 docker run -v /data/zc95:/src --rm ghcr.io/crashoverride85/zc95-build:1.0.0
 ```
 All going well, complied firmware images should appear in /data/zc95/source/CompiledUF2/

--- a/misc/Docker/Dockerfile
+++ b/misc/Docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM alpine:3.23
+
+ENV PICO_SDK_PATH=/pico-sdk
+
+# build environment
+RUN apk add --no-cache \
+    git \
+    python3 \
+    py3-pip \
+    build-base \
+    cmake \
+    newlib-arm-none-eabi \
+    gcc-arm-none-eabi \
+    g++-arm-none-eabi \
+    linux-headers
+
+
+RUN git clone --depth=1 https://github.com/raspberrypi/pico-sdk /pico-sdk
+WORKDIR /pico-sdk
+RUN git submodule update --init --depth=1
+
+RUN git clone https://github.com/raspberrypi/picotool.git /picotool
+RUN mkdir /picotool/build
+WORKDIR /picotool/build
+RUN cmake .. \
+ && make -j4 \
+ && make install \
+ && rm -r /picotool
+
+RUN git config --global safe.directory '*' 
+
+ADD build.sh /build.sh
+
+WORKDIR /src
+CMD ["/bin/sh", "/build.sh"]
+

--- a/misc/Docker/README.md
+++ b/misc/Docker/README.md
@@ -1,0 +1,22 @@
+Dockerfile to build the `ghcr.io/crashoverride85/zc95-build` image, which can be used to build the zc95 firmware binaries. Loosely based on a dockerfile & build script written by [censor](https://discord.com/channels/720377642813095956/1303831389199794176/1354199647630917633), and a [forum post](https://forums.raspberrypi.com/viewtopic.php?t=318850) by mvcorrea.
+
+Build:
+
+``` 
+docker build -t ghcr.io/crashoverride85/zc95-build:latest .
+```
+
+Use:
+```
+docker run -v <path to repo>:/src --rm ghcr.io/crashoverride85/zc95-build:latest
+```
+
+e.g.
+
+```
+docker run -v /home/crashoverride/zc95:/src --rm ghcr.io/crashoverride85/zc95-build:latest
+```
+
+After it completes, the complied binaries should be in `zc95/source/CompiledUF2/`
+
+Will only build dev & version >2.1.

--- a/misc/Docker/build.sh
+++ b/misc/Docker/build.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+mkdir -p /src/source/CompiledUF2
+
+cd /src/source/zc95Bootloader
+rm -f CMakeCache.txt 
+mkdir -p build
+cd build
+rm -f CMakeCache.txt 
+cmake -DCMAKE_BUILD_TYPE=MinSizeRel ..
+make
+
+cd /src/source/zc95
+rm -f CMakeCache.txt 
+mkdir -p build
+cd build
+rm -f CMakeCache.txt 
+cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
+make -j8
+cp zc95.uf2 /src/source/CompiledUF2/zc95.uf2
+
+cd /src/source/zc624Bootloader
+rm -f CMakeCache.txt 
+mkdir -p build
+cd build
+rm -f CMakeCache.txt 
+cmake ..
+make -j8
+
+cd /src/source/zc624
+rm -f CMakeCache.txt 
+mkdir -p build
+cd build
+rm -f CMakeCache.txt 
+cmake ..
+make -j8
+cp OutputZc.uf2 /src/source/CompiledUF2/OutputZc.uf2
+

--- a/source/.gitignore
+++ b/source/.gitignore
@@ -1,0 +1,2 @@
+CompiledUF2/
+

--- a/source/zc95/PowerManagement/BQ25601.h
+++ b/source/zc95/PowerManagement/BQ25601.h
@@ -28,6 +28,7 @@
  #ifndef _BQ25601_H
  #define _BQ25601_H
  
+ #include <stdint.h>
 
  #define BQ25601_REG00 0x00
  #define BQ25601_REG01 0x01

--- a/source/zc95/RemoteAccess/sha1.c
+++ b/source/zc95/RemoteAccess/sha1.c
@@ -44,7 +44,7 @@ inline const unsigned int rol(const unsigned int value,
 
 // Sets the first 16 integers in the buffert to zero.
 // Used for clearing the W buffert.
-inline void clearWBuffert(unsigned int* buffert)
+void clearWBuffert(unsigned int* buffert)
 {
     for (int pos = 16; --pos >= 0;)
     {

--- a/source/zc95/ZcTypes.h
+++ b/source/zc95/ZcTypes.h
@@ -1,6 +1,8 @@
 #ifndef _ZCTYPES_H
 #define _ZCTYPES_H
 
+#include <stdint.h>
+
 enum class front_panel_version_t
 {
     UNKNOWN,


### PR DESCRIPTION
Initial dockerfile to build the ZC95 firmware files (zc95.uf2 & OutputZc.uf2).

Maybe to follow: updates to allow it to build for the pico2.