### PR TITLE
Minimal support for building for pico2

### DIFF
--- a/docs/SourceBuildNotes.md
+++ b/docs/SourceBuildNotes.md
@@ -7,10 +7,23 @@ Steps to build the dev branch, adjust paths as required:
 ```
 cd /data
 git clone -b dev https://github.com/CrashOverride85/zc95.git --recurse-submodules
-docker run -v /data/zc95:/src --rm ghcr.io/crashoverride85/zc95-build:1.0.0
+docker run -v /data/zc95:/src --rm ghcr.io/crashoverride85/zc95-build:1.1.0
 ```
 All going well, complied firmware images should appear in /data/zc95/source/CompiledUF2/
 
+### pico2
+This project has been designed around and tested with the original pico (rp2040). However if you really want to build for the pico2, add `pico2` as the first and only command line argument to the container, i.e.:
+```
+docker run -v <path to repo>:/src --rm ghcr.io/crashoverride85/zc95-build:1.1.0 pico2
+```
+I do not recommend using pico2's for the zc95:
+
+- This project is likely going to continue to target the original pico(w) for as long as it is readily available in order to remain compatible with exiting zc95's, so the advantages of the pico2 (and there are many) will be wasted
+- It doesn't include the bootloader; so firmware upgrades via serial - and likely later from the UI - won't be possible
+- I'm not going to be routinely testing future changes even build for the pico2, much less work as intended
+- I've barely tested it. On 2026/04/16, it does build from the dev branch, boots up, and appears functional at first glace 🤷‍♂️️
+
+You have been warned.
 
 ## Local setup
 

--- a/misc/Docker/Dockerfile
+++ b/misc/Docker/Dockerfile
@@ -32,5 +32,6 @@ RUN git config --global safe.directory '*'
 ADD build.sh /build.sh
 
 WORKDIR /src
-CMD ["/bin/sh", "/build.sh"]
 
+ENTRYPOINT ["/bin/sh", "/build.sh"]
+CMD ["pico"]

--- a/misc/Docker/README.md
+++ b/misc/Docker/README.md
@@ -19,4 +19,14 @@ docker run -v /home/crashoverride/zc95:/src --rm ghcr.io/crashoverride85/zc95-bu
 
 After it completes, the complied binaries should be in `zc95/source/CompiledUF2/`
 
-Will only build dev & version >2.1.
+Will only build dev & versions >=2.1.
+
+Also see [notes on building source](../../docs/SourceBuildNotes.md).
+
+## Changelog
+
+### v1.1.0
+Add ability to build for pico2 with command line arg
+
+### v1.0.0
+Inital version - builds for pico only

--- a/misc/Docker/build.sh
+++ b/misc/Docker/build.sh
@@ -1,38 +1,80 @@
 #!/bin/sh
 
+# Default board types
+BOARD_TYPE_ZC95="pico_w"
+BOARD_TYPE_ZC624="pico"
+BUILD_BOOTLOADERS=1
+
+if [ "$#" -gt 1 ]; then
+    echo "Error: Too many arguments"
+    exit 1
+fi
+
+if [ "$#" -eq 1 ]; then
+    case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
+        pico)
+            BOARD_TYPE_ZC95="pico_w"
+            BOARD_TYPE_ZC624="pico"
+            BUILD_BOOTLOADERS=1
+            ;;
+        pico2)
+            BOARD_TYPE_ZC95="pico2_w"
+            BOARD_TYPE_ZC624="pico2"
+            BUILD_BOOTLOADERS=0
+            ;;
+        *)
+            echo "Error: Invalid argument '$1' (expected 'pico' or 'pico2')"
+            exit 1
+            ;;
+    esac
+fi
+
+echo "Building with board types:"
+echo "  zc95 : $BOARD_TYPE_ZC95"
+echo "  zc624: $BOARD_TYPE_ZC624"
+echo "  bootloaders: $([ "$BUILD_BOOTLOADERS" -eq 1 ] && echo "yes" || echo "no")"
+echo
+
 mkdir -p /src/source/CompiledUF2
 
-cd /src/source/zc95Bootloader
-rm -f CMakeCache.txt 
-mkdir -p build
-cd build
-rm -f CMakeCache.txt 
-cmake -DCMAKE_BUILD_TYPE=MinSizeRel ..
-make
+# --- build zc95 bootloader (orignal pico only) ---
+if [ "$BUILD_BOOTLOADERS" -eq 1 ]; then
+    cd /src/source/zc95Bootloader || exit 1
+    rm -f CMakeCache.txt
+    mkdir -p build
+    cd build || exit 1
+    rm -f CMakeCache.txt
+    cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DPICO_BOARD="$BOARD_TYPE_ZC95" ..
+    make
+fi
 
-cd /src/source/zc95
-rm -f CMakeCache.txt 
+# --- build zc95 ---
+cd /src/source/zc95 || exit 1
+rm -f CMakeCache.txt
 mkdir -p build
-cd build
-rm -f CMakeCache.txt 
-cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
+cd build || exit 1
+rm -f CMakeCache.txt
+cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DPICO_BOARD="$BOARD_TYPE_ZC95" ..
 make -j8
-cp zc95.uf2 /src/source/CompiledUF2/zc95.uf2
+cp zc95.uf2 /src/source/CompiledUF2/zc95.$BOARD_TYPE_ZC95.uf2
 
-cd /src/source/zc624Bootloader
-rm -f CMakeCache.txt 
+# --- build zc624 bootloader (original pico only) ---
+if [ "$BUILD_BOOTLOADERS" -eq 1 ]; then
+    cd /src/source/zc624Bootloader || exit 1
+    rm -f CMakeCache.txt
+    mkdir -p build
+    cd build || exit 1
+    rm -f CMakeCache.txt
+    cmake ..
+    make -j8
+fi
+
+# --- build zc624 ---
+cd /src/source/zc624 || exit 1
+rm -f CMakeCache.txt
 mkdir -p build
-cd build
-rm -f CMakeCache.txt 
-cmake ..
+cd build || exit 1
+rm -f CMakeCache.txt
+cmake -DPICO_BOARD="$BOARD_TYPE_ZC624" ..
 make -j8
-
-cd /src/source/zc624
-rm -f CMakeCache.txt 
-mkdir -p build
-cd build
-rm -f CMakeCache.txt 
-cmake ..
-make -j8
-cp OutputZc.uf2 /src/source/CompiledUF2/OutputZc.uf2
-
+cp OutputZc.uf2 /src/source/CompiledUF2/OutputZc.$BOARD_TYPE_ZC624.uf2

--- a/source/zc624/CMakeLists.txt
+++ b/source/zc624/CMakeLists.txt
@@ -42,7 +42,12 @@ pico_set_program_version(OutputZc "0.1")
 pico_enable_stdio_uart(OutputZc 1)
 pico_enable_stdio_usb(OutputZc 0)
 
-pico_set_linker_script(OutputZc ${CMAKE_CURRENT_SOURCE_DIR}/memmap.ld)
+if(PICO_PLATFORM STREQUAL "rp2040")
+  target_compile_definitions(OutputZc PRIVATE
+    SYS_CLK_MHZ=200
+  )
+  pico_set_linker_script(OutputZc ${CMAKE_CURRENT_SOURCE_DIR}/memmap.ld)
+endif()
 
 # Add the standard library to the build
 target_link_libraries(OutputZc pico_stdlib)
@@ -61,24 +66,23 @@ target_link_libraries(OutputZc
 pico_add_extra_outputs(OutputZc)
 add_subdirectory(external/pico_i2c_slave)
 
-target_compile_definitions(OutputZc PRIVATE
-  SYS_CLK_MHZ=200
-)
+if(PICO_PLATFORM STREQUAL "rp2040")
+    # Include bootloader
+    set(BOOTLOADER_BIN ${CMAKE_CURRENT_SOURCE_DIR}/../zc624Bootloader/build/zc624Bootloader.bin)
+    set(BOOTLOADER_OBJ ${CMAKE_CURRENT_BINARY_DIR}/zc624Bootloader.o)
 
-# Include bootloader
-set(BOOTLOADER_BIN ${CMAKE_CURRENT_SOURCE_DIR}/../zc624Bootloader/build/zc624Bootloader.bin)
-set(BOOTLOADER_OBJ ${CMAKE_CURRENT_BINARY_DIR}/zc624Bootloader.o)
+    add_custom_command(
+        OUTPUT ${BOOTLOADER_OBJ}
+        COMMAND ${CMAKE_OBJCOPY}
+                -I binary
+                -O elf32-littlearm
+                -B arm
+                ${BOOTLOADER_BIN}
+                ${BOOTLOADER_OBJ}
+        DEPENDS ${BOOTLOADER_BIN}
+        COMMENT "Converting zc624Bootloader.bin to object"
+        VERBATIM
+    )
+endif()
 
-add_custom_command(
-    OUTPUT ${BOOTLOADER_OBJ}
-    COMMAND ${CMAKE_OBJCOPY}
-            -I binary
-            -O elf32-littlearm
-            -B arm
-            ${BOOTLOADER_BIN}
-            ${BOOTLOADER_OBJ}
-    DEPENDS ${BOOTLOADER_BIN}
-    COMMENT "Converting zc624Bootloader.bin to object"
-    VERBATIM
-)
 target_sources(OutputZc PRIVATE ${BOOTLOADER_OBJ})

--- a/source/zc95/CMakeLists.txt
+++ b/source/zc95/CMakeLists.txt
@@ -2,7 +2,9 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-set(PICO_BOARD pico_w)
+if (NOT DEFINED PICO_BOARD)
+    set(PICO_BOARD pico_w CACHE STRING "Board type")
+endif()
 
 # add_compile_options(-Wall -Wextra -pedantic -Werror)
 
@@ -203,7 +205,12 @@ pico_set_program_version(zc95 "1.0")
 pico_enable_stdio_uart(zc95 1)
 pico_enable_stdio_usb(zc95 0)
 
-pico_set_linker_script(zc95 ${CMAKE_CURRENT_SOURCE_DIR}/memmap.ld)
+if(PICO_PLATFORM STREQUAL "rp2040")
+  target_compile_definitions(zc95 PRIVATE
+    SYS_CLK_MHZ=200
+  )
+  pico_set_linker_script(zc95 ${CMAKE_CURRENT_SOURCE_DIR}/memmap.ld)
+endif()
 
 # Add the standard library to the build
 target_link_libraries(zc95 pico_stdlib)
@@ -247,7 +254,6 @@ target_compile_definitions(zc95 PRIVATE
   PICO_STACK_SIZE=8192
   PICO_CORE1_STACK_SIZE=0 # stack is malloc'd
   PICO_USE_STACK_GUARDS   # would rather die instantly on stack overflow, than get weird, hard to debug, errors
-  SYS_CLK_MHZ=200
   # For Lua. If a Lua script consumes all the memory, Lua can handle that and give an OOM error, which is better 
   # than crashing with a Panic. Ideally Lua would use a seperate alloc function that didn't panic, whilst everything
   # else did. Not quite sure how to manage that yet; multicore/malloc mutex complicates things.
@@ -291,20 +297,23 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ${PICO_SDK_PATH}/lib/lwip/include/lwip/apps
 )
 
-# Include bootloader
-set(BOOTLOADER_BIN ${CMAKE_CURRENT_SOURCE_DIR}/../zc95Bootloader/build/zc95Bootloader.bin)
-set(BOOTLOADER_OBJ ${CMAKE_CURRENT_BINARY_DIR}/zc95Bootloader.o)
+if(PICO_PLATFORM STREQUAL "rp2040")
+  # Include bootloader
+  set(BOOTLOADER_BIN ${CMAKE_CURRENT_SOURCE_DIR}/../zc95Bootloader/build/zc95Bootloader.bin)
+  set(BOOTLOADER_OBJ ${CMAKE_CURRENT_BINARY_DIR}/zc95Bootloader.o)
 
-add_custom_command(
-    OUTPUT ${BOOTLOADER_OBJ}
-    COMMAND ${CMAKE_OBJCOPY}
-            -I binary
-            -O elf32-littlearm
-            -B arm
-            ${BOOTLOADER_BIN}
-            ${BOOTLOADER_OBJ}
-    DEPENDS ${BOOTLOADER_BIN}
-    COMMENT "Converting zc95Bootloader.bin to object"
-    VERBATIM
-)
+  add_custom_command(
+      OUTPUT ${BOOTLOADER_OBJ}
+      COMMAND ${CMAKE_OBJCOPY}
+              -I binary
+              -O elf32-littlearm
+              -B arm
+              ${BOOTLOADER_BIN}
+              ${BOOTLOADER_OBJ}
+      DEPENDS ${BOOTLOADER_BIN}
+      COMMENT "Converting zc95Bootloader.bin to object"
+      VERBATIM
+  )
+endif()
+
 target_sources(zc95 PRIVATE ${BOOTLOADER_OBJ})

--- a/source/zc95/HwCheck/CHwCheck.cpp
+++ b/source/zc95/HwCheck/CHwCheck.cpp
@@ -176,6 +176,12 @@ void CHwCheck::check_part1()
     }
 
     // Start main firmware on zc624 (i.e. exit bootloader)
+#ifdef PICO_RP2350
+    // If running on Pico2's, there (currently) isn't a bootloader. If the zc624 is an original
+    // pico (with a bootloader) and we're running on a pico2, then by the time we hit this point, 
+    // the 624 isn't going to be ready to respond. Give it time to start up.
+    sleep_ms(500);
+#endif
     _zc624_comms->exit_bootloader();
 
     if (ok)

--- a/source/zc95/zc95.cpp
+++ b/source/zc95/zc95.cpp
@@ -34,6 +34,8 @@
 #include "hardware/regs/rosc.h"
 #include "hardware/regs/addressmap.h"
 #include "hardware/adc.h"
+#include "hardware/structs/xip_ctrl.h"
+
 
 #include "CLedControl.h"
 #include "Hal/IHal.h"
@@ -158,6 +160,17 @@ int main()
 {
     // Debugging with picoprobe causes cyw43_arch_init() to hang without this. JLink doesn't need it though ¯\_(ツ)_/¯
     timer_hw->dbgpause = 0; 
+
+#ifdef PICO_RP2350
+    // When uploading then debugging with JLINK (tested with 8.42) it leaves the XIP cache disabled, which absolutely kills performance.
+    // See: https://forum.segger.com/index.php?thread/9782-rp2350-xip-cache-not-re-enabled-after-flash-loader/&postID=34698
+    uint32_t xip_ctl = xip_ctrl_hw->ctrl;
+    if (xip_ctl != 131)
+    {
+        printf("XIP ctrl register does not match expected power on default of 0x%X, resetting (was 0x%X)\n", 131, xip_ctrl_hw->ctrl);
+        xip_ctrl_hw->ctrl = 131;
+    }
+#endif
 
     CSavedSettings* settings = NULL;
     CLedControl led = CLedControl(PIN_LED, &settings);


### PR DESCRIPTION
Tweaks to allow the project to build for the pico 2(w).

Largely untested on the pico2, beyond a basic power on test. 

Instead of writing a bootloader for the pico2, this change removes it when targeting the pico 2.