### PR TITLE
Ramp tweaks

### DIFF
--- a/docs/Operation.md
+++ b/docs/Operation.md
@@ -65,6 +65,7 @@ Configuration options so far:
     * Show ramp start - Yes or No. If Yes, when running a pattern the top item on the list will always be "Ramp start". To start the ramp up, select this option, and press the top left soft button (labelled "Start"). 
     * Start level - 1% - 100%. At what percentage of the power selected on the front panel does the ramp start. Setting to 100% effectively disables the ramp function
     * Time per p.p. - Time taken in seconds to increase the power level by one percentage point. This increase is relatively smooth, and will increase the power level in 0.1% increments to achieve the selected rate.
+    * Ramp shape - Affects how the ramp is performed. -ve values result in a fast initial rise that slows down as the ramp progresses. +ve values result in a slow initial rise, which speeds up as the ramp progresses. The graph on screen gives a visual representation of how the ramp will progress for the selected value. The default setting of 0 results in a linear rise (which is how the ramp functioned prior to this setting).
 
     With either "Start level" or "Time per p.p." selected, the bottom of the menu will indicate the estimated time in minutes for the ramp to complete.
 

--- a/docs/Operation.md
+++ b/docs/Operation.md
@@ -66,6 +66,7 @@ Configuration options so far:
     * Start level - 1% - 100%. At what percentage of the power selected on the front panel does the ramp start. Setting to 100% effectively disables the ramp function
     * Time per p.p. - Time taken in seconds to increase the power level by one percentage point. This increase is relatively smooth, and will increase the power level in 0.1% increments to achieve the selected rate.
     * Ramp shape - Affects how the ramp is performed. -ve values result in a fast initial rise that slows down as the ramp progresses. +ve values result in a slow initial rise, which speeds up as the ramp progresses. The graph on screen gives a visual representation of how the ramp will progress for the selected value. The default setting of 0 results in a linear rise (which is how the ramp functioned prior to this setting).
+    * Show on status bar - if set to "Yes", shows the progress in percent and the ramp time remaining in the status bar whilst the ramp is running.
 
     With either "Start level" or "Time per p.p." selected, the bottom of the menu will indicate the estimated time in minutes for the ramp to complete.
 
@@ -90,6 +91,8 @@ Configuration options so far:
     - Running pattern - name of the currently running pattern, or blank if nothing running. This is what MKI's show
     - Battery current - current draw from battery in mA. -ve indicates current being drawn from battery, +ve current going into battery (i.e. charging).
       For PCB versions >= 2.3, this may go negative even when plugged in, as if the charger can't supply enough current, the difference will come from the battery.
+
+    Note that if the extended ramp configuration has been set to show progress on the status bar, that will override this setting whilst the ramp is in progress.
 
 * Audio input - Displayed if audio board present by default, depends on "Hardware config > Audio" setting. See [Audio Input](./AudioInput-Operation.md)
 

--- a/source/zc95/CSavedSettings.cpp
+++ b/source/zc95/CSavedSettings.cpp
@@ -540,6 +540,8 @@ uint8_t CSavedSettings::get_extended_ramp_level()
     uint8_t level = _eeprom_contents[(uint8_t)setting::ExtendedRampLevel];
     if (level == 0) // not valid, will be 0 after upgrading from f/w without this option. Use default.
         return 70;
+    else if (level > 99)
+        return 99;
     else
         return level;
 }
@@ -558,14 +560,36 @@ uint8_t CSavedSettings::get_extended_ramp_time_seconds()
         return seconds;
 }
 
-bool CSavedSettings::get_extended_ramp_show()
+bool CSavedSettings::get_extended_ramp_show_menu_option()
 {
-    return (_eeprom_contents[(uint8_t)setting::ExtendedRampShow] != 0);
+    return (_eeprom_contents[(uint8_t)setting::ExtendedRampShow] & (uint8_t)extended_ramp_show_bitmask_t::EXT_RAMP_SHOW_ON_PATTERN_MENU);
 }
 
-void CSavedSettings::set_extended_ramp_show(bool show)
+void CSavedSettings::set_extended_ramp_show_menu_option(bool show)
 {
-    _eeprom_contents[(uint8_t)setting::ExtendedRampShow] = show;
+    uint8_t value = _eeprom_contents[(uint8_t)setting::ExtendedRampShow];
+    if (show)
+        value |= (uint8_t)extended_ramp_show_bitmask_t::EXT_RAMP_SHOW_ON_PATTERN_MENU;
+    else
+        value &= ~((uint8_t)extended_ramp_show_bitmask_t::EXT_RAMP_SHOW_ON_PATTERN_MENU);
+
+    _eeprom_contents[(uint8_t)setting::ExtendedRampShow] = value;
+}
+
+bool CSavedSettings::get_extended_ramp_show_on_status_bar()
+{
+    return (_eeprom_contents[(uint8_t)setting::ExtendedRampShow] & (uint8_t)extended_ramp_show_bitmask_t::EXT_RAMP_SHOW_PROGRESS_ON_STATUS_BAR);
+}
+
+void CSavedSettings::set_extended_ramp_show_on_status_bar(bool show)
+{
+    uint8_t value = _eeprom_contents[(uint8_t)setting::ExtendedRampShow];
+    if (show)
+        value |= (uint8_t)extended_ramp_show_bitmask_t::EXT_RAMP_SHOW_PROGRESS_ON_STATUS_BAR;
+    else
+        value &= ~((uint8_t)extended_ramp_show_bitmask_t::EXT_RAMP_SHOW_PROGRESS_ON_STATUS_BAR);
+
+    _eeprom_contents[(uint8_t)setting::ExtendedRampShow] = value;
 }
 
 void CSavedSettings::set_extended_ramp_time_seconds(uint8_t seconds)

--- a/source/zc95/CSavedSettings.cpp
+++ b/source/zc95/CSavedSettings.cpp
@@ -593,6 +593,16 @@ void CSavedSettings::set_bootloader_mode(bootloader_mode_t mode)
     _eeprom_contents[(uint8_t)setting::BootloaderMode] = (uint8_t)mode;
 }
 
+int8_t CSavedSettings::get_extended_ramp_shape()
+{
+    return (int8_t)(_eeprom_contents[(uint8_t)setting::ExtenedRampShape]);
+}
+
+void CSavedSettings::set_extended_ramp_shape(int8_t shape)
+{
+    _eeprom_contents[(uint8_t)setting::ExtenedRampShape] = (uint8_t)shape;
+}
+
 bool CSavedSettings::eeprom_initialised()
 {
     return (_eeprom->read((uint16_t)setting::EepromInit) == EEPROM_MAGIC_VAL);

--- a/source/zc95/CSavedSettings.h
+++ b/source/zc95/CSavedSettings.h
@@ -74,7 +74,8 @@ class CSavedSettings
         ExtenedRampTime  = 229, // Extended ramp time. 1 - 200 (seconds)
         ExtendedRampShow = 230, // Show 'Ramp start' option on all patterns
         LedColourFormat  = 231, // Colour format (RBG, BGR, etc) of front panel LED buttons
-        BootloaderMode   = EEPROM_BOOTLOADER_SETTING_ADDR  // (232) What the bootloader should do on next startup. Added as #define as it's shared with the bootload code
+        BootloaderMode   = EEPROM_BOOTLOADER_SETTING_ADDR, // (232) What the bootloader should do on next startup. Added as #define as it's shared with the bootloader code
+        ExtenedRampShape = 233
     };
 
     public:
@@ -286,6 +287,9 @@ class CSavedSettings
 
         bootloader_mode_t get_bootloader_mode();
         void set_bootloader_mode(bootloader_mode_t mode);
+
+        int8_t get_extended_ramp_shape();
+        void set_extended_ramp_shape(int8_t shape);
 
         void eeprom_initialise();
 

--- a/source/zc95/CSavedSettings.h
+++ b/source/zc95/CSavedSettings.h
@@ -72,7 +72,7 @@ class CSavedSettings
         DisplayBrightness= 227, // Display brightness, in percent
         ExtendedRampLevel= 228, // Extended ramp percent, 1% - 100%
         ExtenedRampTime  = 229, // Extended ramp time. 1 - 200 (seconds)
-        ExtendedRampShow = 230, // Show 'Ramp start' option on all patterns
+        ExtendedRampShow = 230, // Show 'Ramp start' option on all patterns, and should progress be displayed on the status bar
         LedColourFormat  = 231, // Colour format (RBG, BGR, etc) of front panel LED buttons
         BootloaderMode   = EEPROM_BOOTLOADER_SETTING_ADDR, // (232) What the bootloader should do on next startup. Added as #define as it's shared with the bootloader code
         ExtenedRampShape = 233
@@ -163,6 +163,12 @@ class CSavedSettings
             NORMAL_BOOT      = EEPROM_BOOTLOADER_SETTING_NORMAL,
             RESTORE_PENDING  = EEPROM_BOOTLOADER_SETTING_RESTORE_PENDING,
             RESTORE_PREVIOUS = EEPROM_BOOTLOADER_SETTING_RESTORE_PREV
+        };
+
+        enum class extended_ramp_show_bitmask_t
+        {
+            EXT_RAMP_SHOW_ON_PATTERN_MENU           = 1,
+            EXT_RAMP_SHOW_PROGRESS_ON_STATUS_BAR    = 2
         };
 
         CSavedSettings(CEeprom *eeprom);
@@ -279,8 +285,11 @@ class CSavedSettings
         uint8_t get_extended_ramp_time_seconds();
         void set_extended_ramp_time_seconds(uint8_t seconds);
 
-        bool get_extended_ramp_show();
-        void set_extended_ramp_show(bool show);
+        bool get_extended_ramp_show_menu_option();
+        void set_extended_ramp_show_menu_option(bool show);
+
+        bool get_extended_ramp_show_on_status_bar();
+        void set_extended_ramp_show_on_status_bar(bool show);
 
         led_colour_format_t get_led_colour_format();
         void set_led_colour_format(led_colour_format_t colour_format);

--- a/source/zc95/core1/CPowerLevelControl.cpp
+++ b/source/zc95/core1/CPowerLevelControl.cpp
@@ -168,7 +168,7 @@ uint16_t CPowerLevelControl::get_max_power_level(uint8_t channel)
         selected_power = (float)selected_power * ((float)_initial_ramp_percent / (float)100);
     
     if (_extended_ramp.ramp_in_progress())
-        selected_power = (float)selected_power * (_extended_ramp.get_ramp_percent() / (float)100);
+        selected_power = (float)selected_power * (_extended_ramp.get_ramp_power_percent() / (float)100);
     
     return selected_power;
 }
@@ -269,5 +269,5 @@ void CPowerLevelControl::calc_output_power(uint8_t channel)
 
     _output_power[channel] = scaled_power 
                 * ((float)_initial_ramp_percent / (float)100)
-                * (_extended_ramp.get_ramp_percent() / (float)100);
+                * (_extended_ramp.get_ramp_power_percent() / (float)100);
 }

--- a/source/zc95/core1/CPowerLevelControl.cpp
+++ b/source/zc95/core1/CPowerLevelControl.cpp
@@ -182,6 +182,24 @@ uint16_t CPowerLevelControl::get_target_max_power_level(uint8_t channel)
     return _front_panel_power[channel];
 }
 
+void CPowerLevelControl::get_extended_ramp_progress(uint8_t* out_percent, uint16_t* out_secs_remain)
+{
+    if (!_extended_ramp.ramp_in_progress())
+    {
+        *out_percent = 0xFF;
+        *out_secs_remain = 0xFFFF;
+        return;
+    }
+
+    float percent_progress = _extended_ramp.get_ramp_progress_percent();
+
+    uint8_t steps = 100 - _saved_settings->get_extended_ramp_level();
+    int total_duration_seconds = steps * _saved_settings->get_extended_ramp_time_seconds();
+
+    *out_secs_remain = total_duration_seconds - ((float)total_duration_seconds * (percent_progress / (float)100));
+    *out_percent = (uint8_t)percent_progress;
+}
+
 void CPowerLevelControl::initial_ramp_start()
 {
     // How often should the power level be increased.

--- a/source/zc95/core1/CPowerLevelControl.h
+++ b/source/zc95/core1/CPowerLevelControl.h
@@ -53,6 +53,10 @@ class CPowerLevelControl
         // Start the extended ramp. This is started from the menu and can last from a few minutes to over an hour (config dependant)
         void extended_ramp_start();
 
+        // If extended ramp is active, returns the progress in percent, and the number of seconds remaining.
+        // If not active, returns 0xFF and 0xFFFF for percent and seconds remaining respectively. 
+        void get_extended_ramp_progress(uint8_t* out_percent, uint16_t* out_secs_remain);
+
         void zero_power_level();
 
         void loop();

--- a/source/zc95/core1/CPowerLevelRamp.cpp
+++ b/source/zc95/core1/CPowerLevelRamp.cpp
@@ -35,6 +35,16 @@ float CPowerLevelRamp::get_ramp_power_percent()
     return shape_adjusted_ramp * 100;
 }
 
+float CPowerLevelRamp::get_ramp_progress_percent()
+{
+    if (!_ramp_in_progress)
+        return 100;
+
+    // Calculate the progress through the ramp, in percent. This will always be 0-100%, i.e. 
+    // it won't start at what's configured as the "Start level" like _ramp_percent does.
+    return (_ramp_percent-_saved_settings->get_extended_ramp_level()) * ((float)100 / (float)((float)100 - (float)_saved_settings->get_extended_ramp_level()));
+}
+
 bool CPowerLevelRamp::ramp_in_progress()
 {
     return _ramp_in_progress;

--- a/source/zc95/core1/CPowerLevelRamp.cpp
+++ b/source/zc95/core1/CPowerLevelRamp.cpp
@@ -67,7 +67,6 @@ void CPowerLevelRamp::calc_ramp_percent()
     }
 }
 
-
 // k = ramp shape: -ve values will cause a fast initial rise, then slow down. +ve values will cause a slow inital rise, then speed up.
 //                  0 will result in a purley linear rise (return value = t)
 // t = time, 0 to 1, i.e. 0.5 = 50% through the ramp time-wise 

--- a/source/zc95/core1/CPowerLevelRamp.cpp
+++ b/source/zc95/core1/CPowerLevelRamp.cpp
@@ -1,4 +1,5 @@
 #include "CPowerLevelRamp.h"
+#include <math.h>
 
 CPowerLevelRamp::CPowerLevelRamp(CSavedSettings *saved_settings)
 {
@@ -24,9 +25,14 @@ bool CPowerLevelRamp::loop()
     return false;
 }
 
-float CPowerLevelRamp::get_ramp_percent()
+float CPowerLevelRamp::get_ramp_power_percent()
 {
-    return _ramp_in_progress ? _ramp_percent : 100;
+    if (!_ramp_in_progress)
+        return 100;
+
+    float shape = (float)_saved_settings->get_extended_ramp_shape() / (float)10;
+    float shape_adjusted_ramp = s_normalized_exponential(shape, _ramp_percent / (float)100);
+    return shape_adjusted_ramp * 100;
 }
 
 bool CPowerLevelRamp::ramp_in_progress()
@@ -59,4 +65,21 @@ void CPowerLevelRamp::calc_ramp_percent()
         _ramp_percent = 100;
         _ramp_in_progress = false;
     }
+}
+
+
+// k = ramp shape: -ve values will cause a fast initial rise, then slow down. +ve values will cause a slow inital rise, then speed up.
+//                  0 will result in a purley linear rise (return value = t)
+// t = time, 0 to 1, i.e. 0.5 = 50% through the ramp time-wise 
+// Output is 0 to 1, which should be mapped onto an output level of 0 to 1000.
+float CPowerLevelRamp::s_normalized_exponential(float k, float t)
+{
+    // As k -> 0, the function approaches t
+    if (fabsf(k) < 1e-9)
+    {
+        return t;
+    }
+
+    return (exp(k * t) - 1.0) /
+           (exp(k) - 1.0);
 }

--- a/source/zc95/core1/CPowerLevelRamp.h
+++ b/source/zc95/core1/CPowerLevelRamp.h
@@ -11,9 +11,12 @@ class CPowerLevelRamp
         CPowerLevelRamp(CSavedSettings *saved_settings);
         void ramp_start();
         bool loop();
-        float get_ramp_percent();
+        float get_ramp_power_percent();
         bool ramp_in_progress();
         void reset();
+
+        // used for ramp shape - both during ramp, and on the ramp config screen
+        static float s_normalized_exponential(float k, float t);
 
     private:
         void calc_ramp_percent();

--- a/source/zc95/core1/CPowerLevelRamp.h
+++ b/source/zc95/core1/CPowerLevelRamp.h
@@ -12,6 +12,7 @@ class CPowerLevelRamp
         void ramp_start();
         bool loop();
         float get_ramp_power_percent();
+        float get_ramp_progress_percent();
         bool ramp_in_progress();
         void reset();
 

--- a/source/zc95/core1/CRoutineOutputCore1.cpp
+++ b/source/zc95/core1/CRoutineOutputCore1.cpp
@@ -332,7 +332,16 @@ void CRoutineOutputCore1::process_message(message msg)
                 _menu_change_callback(menu_change_msg);
             }
             break;
+
+        case MESSAGE_EXTENDED_RAMP_PROGRESS:
+        {
+            uint8_t percent = msg.msg8[1];
+            uint16_t seconds_remaining = msg.msg8[2];
+            seconds_remaining |= msg.msg8[3] << 8;
+            _display->set_extended_ramp_progress(percent, seconds_remaining);
+            break;
         }
+    }
 }
 
 void CRoutineOutputCore1::process_text_message_queue()

--- a/source/zc95/core1/Core1.cpp
+++ b/source/zc95/core1/Core1.cpp
@@ -145,6 +145,7 @@ void Core1::loop()
         _channel_config->loop();
 
     update_power_levels();
+    update_extended_ramp_progress();
     process_messages();
     check_validity_of_lua_script();
 
@@ -204,6 +205,29 @@ void Core1::update_power_levels()
                 multicore_fifo_push_blocking(msg.msg32);
                 _output_power_max[channel_number] = power_level_max;
             }
+        }
+    }
+}
+
+void Core1::update_extended_ramp_progress()
+{
+    uint8_t new_percent = 0xFF;
+    uint16_t new_secs_remain = 0xFFFF;
+
+    _power_level_control->get_extended_ramp_progress(&new_percent, &new_secs_remain);
+    if (new_percent != _extended_ramp_percent || new_secs_remain != _extended_ramp_remaining_seconds)
+    {
+        message msg = {0};
+        msg.msg8[0] = MESSAGE_EXTENDED_RAMP_PROGRESS;
+        msg.msg8[1] = new_percent;
+        msg.msg8[2] = new_secs_remain & 0xFF;
+        msg.msg8[3] = (new_secs_remain >> 8) & 0xFF;
+
+        if (multicore_fifo_wready())
+        {
+            multicore_fifo_push_blocking(msg.msg32);
+            _extended_ramp_percent = new_percent;
+            _extended_ramp_remaining_seconds = new_secs_remain;
         }
     }
 }

--- a/source/zc95/core1/Core1.h
+++ b/source/zc95/core1/Core1.h
@@ -46,6 +46,7 @@ class Core1
         void process_messages();
         void process_message(message msg);
         void update_power_levels();
+        void update_extended_ramp_progress();
         void set_output_chanels_to_off(bool enable_channel_isolation);
         void process_audio_pulse_queue();
         void check_validity_of_lua_script();
@@ -64,6 +65,8 @@ class Core1
         pulse_message_t _pulse_messages[MAX_CHANNELS] = {0};
         lua_script_state_t _script_script_state = lua_script_state_t::NOT_APPLICABLE;
         CPowerLevelControl *_power_level_control;
+        uint8_t _extended_ramp_percent = 0xFF;
+        uint16_t _extended_ramp_remaining_seconds = 0xFFFF;
 };
 
 Core1* core1_start(std::vector<CRoutines::Routine>& routines, CSavedSettings *saved_settings);

--- a/source/zc95/core1/Core1Messages.h
+++ b/source/zc95/core1/Core1Messages.h
@@ -41,6 +41,8 @@
 #define MESSAGE_SET_AUDIO_MODE              131
 #define MESSAGE_SET_MENU_VALUE              132
 
+#define MESSAGE_EXTENDED_RAMP_PROGRESS      140
+
 enum class lua_script_state_t { NOT_APPLICABLE = 0, VALID = 1 , INVALID = 2};
 
 union __attribute__((packed)) message

--- a/source/zc95/core1/routines/CAudioWave.cpp
+++ b/source/zc95/core1/routines/CAudioWave.cpp
@@ -82,7 +82,7 @@ void CAudioWave::get_config(struct routine_conf *conf)
 
 void CAudioWave::menu_min_max_change(uint8_t menu_id, int16_t new_value) 
 {
-    if (menu_id = menu_ids::AUDIO_RANGE && new_value >= 1 && new_value <= 100)
+    if (menu_id == menu_ids::AUDIO_RANGE && new_value >= 1 && new_value <= 100)
         _range_percent = new_value;
 }
 

--- a/source/zc95/display/CDisplay.cpp
+++ b/source/zc95/display/CDisplay.cpp
@@ -191,6 +191,12 @@ void CDisplay::set_power_level(uint8_t channel, int16_t front_panel_power, int16
     _channel_power[channel].max_power = maximum_power;
 }
 
+void CDisplay::set_extended_ramp_progress(uint8_t percent, uint16_t seconds_remaining)
+{
+    _extended_ramp_seconds_remain = seconds_remaining;
+    _extended_ramp_percent = percent;
+}
+
 void CDisplay::set_current_menu(CMenu *menu)
 {
     _current_menu = menu;
@@ -310,12 +316,6 @@ void CDisplay::draw_status_bar()
 {
     char buffer[100] = {0};
 
-    std::string current_mode = "N/A";
-    if (_current_menu)
-    {
-        current_mode = _current_menu->get_title();
-    }
-
     battery_state_t state;
     IPowerManagement::power_status_t power_status = _power_management->power_status();
     if (power_status == IPowerManagement::power_status_t::OnBattery)
@@ -348,15 +348,53 @@ void CDisplay::draw_status_bar()
 
     put_text(buffer, 4, y, hagl_color(_hagl_backend, 0xAA, 0xAA, 0xAA), false, font5x7);
 
-    // Status text: either running pattern or battery current draw
+    // Status text: either running pattern, battery current draw or ramp progress
+    std::string status_text = get_status_bar_text();
+    put_text(status_text, 26, y, hagl_color(_hagl_backend, 0xAA, 0xAA, 0xAA), false, font5x7);
+
+    // Draw H/M/L power indicator (always)
+    uint16_t x = MIPI_DISPLAY_WIDTH - 8;
+    draw_power_level_indicator(x, y-1);
+
+    // If bluetooth is on, show bt symbol in bottom right of screen to the left of the power level indicator
+    x -= 8;
+    draw_bt_logo_if_required(x, y-1);
+}
+
+std::string CDisplay::get_status_bar_text()
+{
+    std::string current_mode = "N/A";
+    if (_current_menu)
+    {
+        current_mode = _current_menu->get_title();
+    }
 
     // Draw status bar text, depending on configured option
     std::string status_text;
-    if (g_SavedSettings->get_status_bar_option() == CSavedSettings::status_bar_text_t::RUNNING_PATTERN)
+    if (g_SavedSettings->get_extended_ramp_show_on_status_bar() && 
+        _extended_ramp_percent != 0xFF && 
+        _extended_ramp_seconds_remain != 0xFFFF && 
+        current_mode != "")
+    {
+        status_text = "Ramp: " + std::to_string(_extended_ramp_percent) + "%, ";
+
+        uint16_t minutes = _extended_ramp_seconds_remain / 60;
+        uint16_t seconds = _extended_ramp_seconds_remain % 60;
+        if (minutes > 0)
+        {
+            status_text += std::to_string(minutes) + "m" +
+                           std::to_string(seconds) + "s";
+        }
+        else
+            status_text += std::to_string(seconds) + "s";
+    }
+
+    else if (g_SavedSettings->get_status_bar_option() == CSavedSettings::status_bar_text_t::RUNNING_PATTERN)
     {
         // name of currently running pattern (if any)
         status_text = current_mode;
     }
+
     else if (g_SavedSettings->get_status_bar_option() == CSavedSettings::status_bar_text_t::BATTERY_CURRENT)
     {
         int16_t current_ma = 0;
@@ -367,15 +405,8 @@ void CDisplay::draw_status_bar()
     {
         status_text = "?";
     }
-    put_text(status_text, 26, y, hagl_color(_hagl_backend, 0xAA, 0xAA, 0xAA), false, font5x7);
 
-    // Draw H/M/L power indicator (always)
-    uint16_t x = MIPI_DISPLAY_WIDTH - 8;
-    draw_power_level_indicator(x, y-1);
-
-    // If bluetooth is on, show bt symbol in bottom right of screen to the left of the power level indicator
-    x -= 8;
-    draw_bt_logo_if_required(x, y-1);
+    return status_text;
 }
 
 void CDisplay::draw_power_level_indicator(int16_t x, int16_t y)

--- a/source/zc95/display/CDisplay.h
+++ b/source/zc95/display/CDisplay.h
@@ -38,6 +38,7 @@ class CDisplay
         void set_option_d(std::string text);
         
         void set_power_level(uint8_t channel, int16_t front_panel_power, int16_t actual_power, int16_t maximum_power, bool remote_mode_active);
+        void set_extended_ramp_progress(uint8_t percent, uint16_t seconds_remaining);
 
         void set_current_menu(CMenu *menu);
 
@@ -70,6 +71,7 @@ class CDisplay
 
         void draw_soft_buttons();
         void draw_status_bar();
+        std::string get_status_bar_text();
         void draw_power_level();
         void draw_bar_graphs();
         void draw_bar(uint8_t bar_number, std::string label, uint16_t max_power, uint16_t front_panel_power, uint16_t current_power, hagl_color_t bar_colour);
@@ -105,6 +107,9 @@ class CDisplay
         CFrontPanel *_front_panel;
         CBluetooth *_bluetooth;
         IPowerManagement* _power_management;
+
+        uint8_t _extended_ramp_percent = 0xFF;
+        uint16_t _extended_ramp_seconds_remain = 0xFFFF;
 };
 
 #endif

--- a/source/zc95/display/CMenuRoutineAdjust.cpp
+++ b/source/zc95/display/CMenuRoutineAdjust.cpp
@@ -44,7 +44,7 @@ CMenuRoutineAdjust::CMenuRoutineAdjust(
     routine_ptr->get_config(&_active_routine_conf);
     delete routine_ptr;
 
-    _show_ramp_start = _saved_settings->get_extended_ramp_show();
+    _show_ramp_start = _saved_settings->get_extended_ramp_show_menu_option();
 
     if (_show_ramp_start)
     {

--- a/source/zc95/display/config/CMenuSettingOutputExtRamp.cpp
+++ b/source/zc95/display/config/CMenuSettingOutputExtRamp.cpp
@@ -20,6 +20,7 @@
 #include "CMenuSettings.h"
 #include "../CDebugOutput.h"
 #include "../../common/zc95_config.h"
+#include "../core1/CPowerLevelRamp.h"
 #include <math.h>
 
 
@@ -331,7 +332,7 @@ void CMenuSettingOutputExtRamp::draw_shape_graph(int8_t shape)
 
         // IMPORTANT: in eeprom and on the display, 'shape' is stored as an int between -100 and +100. 
         //            But when passed to normalized_exponential, it's divided by 10.
-        float ramp_output = normalized_exponential((float)shape/(float)10, ramp_progress); 
+        float ramp_output = CPowerLevelRamp::s_normalized_exponential((float)shape/(float)10, ramp_progress); 
 
         int16_t y = _setting_choice_area.y1-1 - (int16_t)((float)height * (float)ramp_output);
         hagl_put_pixel(_display->get_hagl_backed(), x, y, green);
@@ -346,20 +347,4 @@ void CMenuSettingOutputExtRamp::draw_shape_graph(int8_t shape)
     std::ostringstream oss;
     oss << "Shape: " << std::to_string(shape);
     _display->put_text(oss.str(), _duration_area.x0, _duration_area.y1-_display->get_font_height(), hagl_color(_display->get_hagl_backed(), 0x55, 0x55, 0x55));
-}
-
-// k = curve shape: -ve values will cause a fast initial rise, then slow down. +ve values will cause a slow inital rise, then speed up.
-//                  0 will result in a purley linear rise (return value = t)
-// t = time, 0 to 1, i.e. 0.5 = 50% through the ramp time-wise 
-// Output is 0 to 1, which should be mapped onto an output level of 0 to 1000.
-float CMenuSettingOutputExtRamp::normalized_exponential(float k, float t)
-{
-    // As k -> 0, the function approaches t
-    if (fabsf(k) < 1e-9)
-    {
-        return t;
-    }
-
-    return (exp(k * t) - 1.0) /
-           (exp(k) - 1.0);
 }

--- a/source/zc95/display/config/CMenuSettingOutputExtRamp.cpp
+++ b/source/zc95/display/config/CMenuSettingOutputExtRamp.cpp
@@ -20,6 +20,7 @@
 #include "CMenuSettings.h"
 #include "../CDebugOutput.h"
 #include "../../common/zc95_config.h"
+#include <math.h>
 
 
 CMenuSettingOutputExtRamp::CMenuSettingOutputExtRamp(CDisplay* display, IHal *hal, CSavedSettings *saved_settings)
@@ -121,22 +122,28 @@ void CMenuSettingOutputExtRamp::adjust_rotary_encoder_change(int8_t change)
                 _settings_choice_list->up();
             }
         }
-        else if (get_setting_kind(get_currently_selected_setting_id()) == setting_kind_t::MIN_MAX)
+        else if (
+                    (get_setting_kind(get_currently_selected_setting_id()) == setting_kind_t::MIN_MAX) ||
+                    (get_setting_kind(get_currently_selected_setting_id()) == setting_kind_t::RAMP_SHAPE_GRAPH)
+                )
         {
             if (change >= 1)
             {
                 if (_min_max_value < _min_max_value_max)
                 {
-                    _min_max_value++;
+                    _min_max_value += _min_max_step_size;
                 }
             }
             else if (change <= -1)
             {
                 if (_min_max_value > _min_max_value_min)
                 {
-                    _min_max_value--;
+                    _min_max_value -= _min_max_step_size;
                 }
             }
+
+            if (_min_max_value > _min_max_value_max) _min_max_value = _min_max_value_max;
+            if (_min_max_value < _min_max_value_min) _min_max_value = _min_max_value_min;
         }
 
         save_setting(_settings_list->get_current_selection(), _settings_choice_list->get_current_selection());
@@ -160,6 +167,10 @@ void CMenuSettingOutputExtRamp::save_setting(uint8_t setting_menu_index, uint8_t
 
         case setting_id_t::RAMP_SHOW:
             _saved_settings->set_extended_ramp_show(choice_id.id);
+            break;
+
+        case setting_id_t::RAMP_SHAPE:
+            _saved_settings->set_extended_ramp_shape(_min_max_value);
             break;
     }
 }
@@ -185,6 +196,12 @@ void CMenuSettingOutputExtRamp::draw()
         {
             hagl_color_t bar_colour = hagl_color(_display->get_hagl_backed(), 0x00, 0x00, 0xFF);
             _bar_graph->draw_horz_bar_graph(_setting_choice_area, _min_max_value_min, _min_max_value_max, _min_max_value, _min_max_uom, bar_colour);
+        }
+            break;
+
+        case setting_kind_t::RAMP_SHAPE_GRAPH:
+        {
+            draw_shape_graph(_min_max_value);
         }
             break;
     };
@@ -213,6 +230,7 @@ void CMenuSettingOutputExtRamp::show()
     _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_SHOW , "Show ramp start"));
     _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_LEVEL, "Start level"));
     _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_TIME , "Time per p.p."));
+    _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_SHAPE, "Ramp shape"));
 
     _settings_list->clear_options();
     for (std::vector<CMenuSettingOutputExtRamp::setting_t>::iterator it = _settings.begin(); it != _settings.end(); it++)
@@ -240,6 +258,7 @@ void CMenuSettingOutputExtRamp::set_options_for_setting(setting_id_t setting_id)
         case setting_id_t::RAMP_LEVEL:
             _min_max_value_min = 1;
             _min_max_value_max = 100; 
+            _min_max_step_size = 1;
             _min_max_uom = "%";
             _min_max_value = _saved_settings->get_extended_ramp_level();
             break;
@@ -247,9 +266,17 @@ void CMenuSettingOutputExtRamp::set_options_for_setting(setting_id_t setting_id)
         case setting_id_t::RAMP_TIME:
             _min_max_value_min = 1;
             _min_max_value_max = 200;
+            _min_max_step_size = 1;
             _min_max_uom = "sec";
             _min_max_value = _saved_settings->get_extended_ramp_time_seconds();
             break;
+
+        case setting_id_t::RAMP_SHAPE:
+            _min_max_value_min = -100;
+            _min_max_value_max = 100;
+            _min_max_step_size = 5;
+            _min_max_uom = ""; // N/A - min/max bar isn't displayed for ramp_shape
+            _min_max_value = _saved_settings->get_extended_ramp_shape();
     }
 
     if (get_setting_kind(setting_id) == setting_kind_t::MULTI_CHOICE)
@@ -276,6 +303,9 @@ CMenuSettingOutputExtRamp::setting_kind_t CMenuSettingOutputExtRamp::get_setting
         case setting_id_t::RAMP_SHOW:
             return setting_kind_t::MULTI_CHOICE;
 
+        case setting_id_t::RAMP_SHAPE:
+            return setting_kind_t::RAMP_SHAPE_GRAPH;
+
         case setting_id_t::RAMP_LEVEL:
         case setting_id_t::RAMP_TIME:
         default:
@@ -286,4 +316,50 @@ CMenuSettingOutputExtRamp::setting_kind_t CMenuSettingOutputExtRamp::get_setting
 CMenuSettingOutputExtRamp::setting_id_t CMenuSettingOutputExtRamp::get_currently_selected_setting_id()
 {
     return (setting_id_t)_settings[_settings_list->get_current_selection()].id;
+}
+
+void CMenuSettingOutputExtRamp::draw_shape_graph(int8_t shape)
+{
+    hagl_color_t green = hagl_color(_display->get_hagl_backed(), 0x00, 0xFF, 0x00);
+    uint16_t x_max = _setting_choice_area.x1;
+
+    uint16_t height = _setting_choice_area.y1 - _setting_choice_area.y0 - 1;\
+
+    for (uint16_t x = 0; x < x_max; x++)
+    {
+        float ramp_progress = (float)x / (float)x_max; // 0.0 to 1.0
+
+        // IMPORTANT: in eeprom and on the display, 'shape' is stored as an int between -100 and +100. 
+        //            But when passed to normalized_exponential, it's divided by 10.
+        float ramp_output = normalized_exponential((float)shape/(float)10, ramp_progress); 
+
+        int16_t y = _setting_choice_area.y1-1 - (int16_t)((float)height * (float)ramp_output);
+        hagl_put_pixel(_display->get_hagl_backed(), x, y, green);
+    }
+
+    hagl_color_t blue = hagl_color(_display->get_hagl_backed(), 0x00, 0x00, 0xFF);
+
+    hagl_draw_rectangle(_display->get_hagl_backed(), _setting_choice_area.x0, _setting_choice_area.y0,
+    _setting_choice_area.x1, _setting_choice_area.y1, blue);
+
+    // Put shape param at bottom in the space usually used to show the calculated duration
+    std::ostringstream oss;
+    oss << "Shape: " << std::to_string(shape);
+    _display->put_text(oss.str(), _duration_area.x0, _duration_area.y1-_display->get_font_height(), hagl_color(_display->get_hagl_backed(), 0x55, 0x55, 0x55));
+}
+
+// k = curve shape: -ve values will cause a fast initial rise, then slow down. +ve values will cause a slow inital rise, then speed up.
+//                  0 will result in a purley linear rise (return value = t)
+// t = time, 0 to 1, i.e. 0.5 = 50% through the ramp time-wise 
+// Output is 0 to 1, which should be mapped onto an output level of 0 to 1000.
+float CMenuSettingOutputExtRamp::normalized_exponential(float k, float t)
+{
+    // As k -> 0, the function approaches t
+    if (fabsf(k) < 1e-9)
+    {
+        return t;
+    }
+
+    return (exp(k * t) - 1.0) /
+           (exp(k) - 1.0);
 }

--- a/source/zc95/display/config/CMenuSettingOutputExtRamp.cpp
+++ b/source/zc95/display/config/CMenuSettingOutputExtRamp.cpp
@@ -167,7 +167,11 @@ void CMenuSettingOutputExtRamp::save_setting(uint8_t setting_menu_index, uint8_t
             break;
 
         case setting_id_t::RAMP_SHOW:
-            _saved_settings->set_extended_ramp_show(choice_id.id);
+            _saved_settings->set_extended_ramp_show_menu_option(choice_id.id);
+            break;
+
+        case setting_id_t::RAMP_SHOW_STS_BAR:
+            _saved_settings->set_extended_ramp_show_on_status_bar(choice_id.id);
             break;
 
         case setting_id_t::RAMP_SHAPE:
@@ -228,10 +232,11 @@ void CMenuSettingOutputExtRamp::show()
     _display->set_option_d("Down");
 
     _settings.clear();
-    _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_SHOW , "Show ramp start"));
-    _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_LEVEL, "Start level"));
-    _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_TIME , "Time per p.p."));
-    _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_SHAPE, "Ramp shape"));
+    _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_SHOW        , "Show ramp start"));
+    _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_LEVEL       , "Start level"));
+    _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_TIME        , "Time per p.p."));
+    _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_SHAPE       , "Ramp shape"));
+    _settings.push_back(CMenuSettingOutputExtRamp::setting_t(setting_id_t::RAMP_SHOW_STS_BAR, "Show on status bar"));
 
     _settings_list->clear_options();
     for (std::vector<CMenuSettingOutputExtRamp::setting_t>::iterator it = _settings.begin(); it != _settings.end(); it++)
@@ -253,7 +258,13 @@ void CMenuSettingOutputExtRamp::set_options_for_setting(setting_id_t setting_id)
         case setting_id_t::RAMP_SHOW:
             _setting_choices.push_back(CMenuSettingOutputExtRamp::setting_t(false, "No" ));
             _setting_choices.push_back(CMenuSettingOutputExtRamp::setting_t(true , "Yes"));
-            current_choice_id = _saved_settings->get_extended_ramp_show();
+            current_choice_id = _saved_settings->get_extended_ramp_show_menu_option();
+            break;
+
+        case setting_id_t::RAMP_SHOW_STS_BAR:
+            _setting_choices.push_back(CMenuSettingOutputExtRamp::setting_t(false, "No" ));
+            _setting_choices.push_back(CMenuSettingOutputExtRamp::setting_t(true , "Yes"));
+            current_choice_id = _saved_settings->get_extended_ramp_show_on_status_bar();
             break;
 
         case setting_id_t::RAMP_LEVEL:
@@ -302,6 +313,7 @@ CMenuSettingOutputExtRamp::setting_kind_t CMenuSettingOutputExtRamp::get_setting
     switch (setting_id)
     {
         case setting_id_t::RAMP_SHOW:
+        case setting_id_t::RAMP_SHOW_STS_BAR:
             return setting_kind_t::MULTI_CHOICE;
 
         case setting_id_t::RAMP_SHAPE:

--- a/source/zc95/display/config/CMenuSettingOutputExtRamp.h
+++ b/source/zc95/display/config/CMenuSettingOutputExtRamp.h
@@ -21,17 +21,21 @@ class CMenuSettingOutputExtRamp : public CMenu
         {
             RAMP_SHOW           = 0,
             RAMP_LEVEL          = 1,
-            RAMP_TIME           = 2
+            RAMP_TIME           = 2,
+            RAMP_SHAPE          = 3
         };
 
         enum setting_kind_t
         {
             MULTI_CHOICE        = 0,
-            MIN_MAX             = 1
+            MIN_MAX             = 1,
+            RAMP_SHAPE_GRAPH    = 2
         };
 
         setting_kind_t get_setting_kind(setting_id_t setting_id);
         setting_id_t get_currently_selected_setting_id();
+        void draw_shape_graph(int8_t shape);
+        float normalized_exponential(float k, float t);
 
         class setting_t
         {
@@ -65,5 +69,6 @@ class CMenuSettingOutputExtRamp : public CMenu
         int16_t _min_max_value = 0;
         int16_t _min_max_value_min = 0;
         int16_t _min_max_value_max = 0;
+        uint8_t _min_max_step_size = 1;
         std::string _min_max_uom = "";
 };

--- a/source/zc95/display/config/CMenuSettingOutputExtRamp.h
+++ b/source/zc95/display/config/CMenuSettingOutputExtRamp.h
@@ -35,7 +35,6 @@ class CMenuSettingOutputExtRamp : public CMenu
         setting_kind_t get_setting_kind(setting_id_t setting_id);
         setting_id_t get_currently_selected_setting_id();
         void draw_shape_graph(int8_t shape);
-        float normalized_exponential(float k, float t);
 
         class setting_t
         {

--- a/source/zc95/display/config/CMenuSettingOutputExtRamp.h
+++ b/source/zc95/display/config/CMenuSettingOutputExtRamp.h
@@ -22,7 +22,8 @@ class CMenuSettingOutputExtRamp : public CMenu
             RAMP_SHOW           = 0,
             RAMP_LEVEL          = 1,
             RAMP_TIME           = 2,
-            RAMP_SHAPE          = 3
+            RAMP_SHAPE          = 3,
+            RAMP_SHOW_STS_BAR   = 4
         };
 
         enum setting_kind_t


### PR DESCRIPTION
Adds:
* Ramp shape - allows for rate of power level change to be controlled - e.g. allowing for a fast initial rise in power, then slowing down
* Allow display of progress through ramp in percent, and time remaining in minutes / seconds in the status bar