### PR TITLE
Allow input on the 3 accessory I/O lines

### DIFF
--- a/docs/LuaNotes.md
+++ b/docs/LuaNotes.md
@@ -353,6 +353,16 @@ Minimal example for using the accessory port to control 3 LEDs. Can be used with
 
 ![acc port]
 
+### AccIoSetInput
+```
+Params:
+    * Accessory I/O line number (1-3)
+```
+Sets an I/O line on the accessory port to be an input, with a weak pull up.
+This is the default state of the lines from power on, and each is reset to be an input when a pattern is started; i.e. there should not normally be a need to call this method.
+
+When the state of an I/O line set to input changes, the `ExternalTrigger` method in the Lua script (if present) is called - see description of `ExternalTrigger` for more details.
+
 ### DelayMs
 ```
 Params:
@@ -375,9 +385,18 @@ Called with `pushed=True` when the top left soft button is pressed, and then aga
 ### ExternalTrigger(socket, part, active)
 Called when an external trigger happens.
 
-Socket: can be either "`TRIGGER1`" or "`TRIGGER2`" for the Trigger1 and Trigger2 sockets respectively. 
+Socket: can be either "`TRIGGER1`", "`TRIGGER2`" or "`ACCESSORY`" for the Trigger1, Trigger2 or Accessory sockets respectively. 
 
-Part: can be either "`A`" or "`B`". With a stereo 3.5mm TRS cable inserted, shorting Tip and Sleeve is part `A` (trigger LED lights up green). Shorting Tip and Ring is part `B` (trigger LED lights up red). When triggered, `active` will be `True`, when released it will be `False`.
+For the 3.5mm trigger sockets, part can be either "`A`" or "`B`". With a stereo 3.5mm TRS cable inserted, shorting Tip and Sleeve is part `A` (trigger LED lights up green). Shorting Tip and Ring is part `B` (trigger LED lights up red). When triggered, `active` will be `True`, when released it will be `False`.
+
+This function will also be called for input on the accessory port. Shorting ACC_IO_1, 2 or 3 to ground will result in a part of A, B or C respectively:
+
+| I/O line | Pin | Part |
+|----------|-----|------|
+| ACC_IO_1 |  9  |  A   |
+| ACC_IO_2 |  4  |  B   |
+| ACC_IO_3 |  8  |  C   |
+| GND      |  5  |      |
 
 ### BluetoothRemoteKeypress (key)
 See bluetooth_fire.lua for an example of this.

--- a/docs/Patterns.md
+++ b/docs/Patterns.md
@@ -349,6 +349,8 @@ Yes! Trigger input 1 needs a stereo Tip, Ring, Sleeve (TRS) 3.5mm plug wired as 
 * Ring = contact at end of wire (green)
 * Sleeve = wire (red)
 
+Alternatively, the accessory socket can be used for input - use ACC_IO_1 for the contact at the end, and ACC_IO_2 for the wire.
+
 
 [Buzz wire game]: images/BuzzGame.jpg "Buzz wire game"
 [Audio Threshold]: images/screen_pattern_audioThreshold.jpg "Audio Threshold"

--- a/source/zc95/Hal/HalDummy.cpp
+++ b/source/zc95/Hal/HalDummy.cpp
@@ -54,7 +54,7 @@ void HalDummy::acc_port_reset()
     
 }
 
-void HalDummy::acc_port_set_io_port_state(ExtInputPort output, bool high)
+void HalDummy::acc_port_set_io_port_state(ExtInputPort output, ExtInputPortState state)
 {
     
 }

--- a/source/zc95/Hal/HalDummy.h
+++ b/source/zc95/Hal/HalDummy.h
@@ -28,7 +28,7 @@ class HalDummy : public IHal
         void loop();
 
         void acc_port_reset();
-        void acc_port_set_io_port_state(ExtInputPort output, bool high);
+        void acc_port_set_io_port_state(ExtInputPort output, ExtInputPortState state);
 
         void audio_input_enable(bool enable);
         void mic_preamp_enable(bool enable);

--- a/source/zc95/Hal/HalMk1.cpp
+++ b/source/zc95/Hal/HalMk1.cpp
@@ -146,9 +146,9 @@ void HalMk1::acc_port_reset()
     _ext_input_port_exp->reset_acc_port();
 }
 
-void HalMk1::acc_port_set_io_port_state(ExtInputPort output, bool high)
+void HalMk1::acc_port_set_io_port_state(ExtInputPort output, ExtInputPortState state)
 {
-    _ext_input_port_exp->set_acc_io_port_state(output, high);
+    _ext_input_port_exp->set_acc_io_port_state(output, state);
 }
 
 void HalMk1::audio_input_enable(bool enable)

--- a/source/zc95/Hal/HalMk1.h
+++ b/source/zc95/Hal/HalMk1.h
@@ -28,7 +28,7 @@ class HalMk1 : public IHal
         void loop();
 
         void acc_port_reset();
-        void acc_port_set_io_port_state(ExtInputPort output, bool high);
+        void acc_port_set_io_port_state(ExtInputPort output, ExtInputPortState state);
 
         void audio_input_enable(bool enable);
         void mic_preamp_enable(bool enable);

--- a/source/zc95/Hal/HalMk2.cpp
+++ b/source/zc95/Hal/HalMk2.cpp
@@ -179,9 +179,9 @@ void HalMk2::acc_port_reset()
     _ext_input_port_exp->reset_acc_port();
 }
 
-void HalMk2::acc_port_set_io_port_state(ExtInputPort output, bool high)
+void HalMk2::acc_port_set_io_port_state(ExtInputPort output, ExtInputPortState state)
 {
-    _ext_input_port_exp->set_acc_io_port_state(output, high);
+    _ext_input_port_exp->set_acc_io_port_state(output, state);
 }
 
 void HalMk2::mic_preamp_enable(bool enable)

--- a/source/zc95/Hal/HalMk2.h
+++ b/source/zc95/Hal/HalMk2.h
@@ -25,7 +25,7 @@ class HalMk2 : public IHal
 
         void loop();
         void acc_port_reset();
-        void acc_port_set_io_port_state(ExtInputPort output, bool high);
+        void acc_port_set_io_port_state(ExtInputPort output, ExtInputPortState state);
 
         void audio_input_enable(bool enable) {};
         void mic_preamp_enable(bool enable);

--- a/source/zc95/Hal/IHal.h
+++ b/source/zc95/Hal/IHal.h
@@ -29,7 +29,7 @@ class IHal
         
         // accessory port
         virtual void acc_port_reset() = 0;
-        virtual void acc_port_set_io_port_state(ExtInputPort output, bool high) = 0;
+        virtual void acc_port_set_io_port_state(ExtInputPort output, ExtInputPortState state) = 0;
 
         // audio
         virtual void audio_input_enable(bool enable) = 0;

--- a/source/zc95/PortExpanders/CExtInputPortExp.cpp
+++ b/source/zc95/PortExpanders/CExtInputPortExp.cpp
@@ -51,9 +51,9 @@ void CExtInputPortExp::clear_input()
     _input_states_at_last_check = _last_read;
     update_trigger_leds();
 
-    _port_exp->set_pin_as_output((int)ExtInputPort::ACC_IO_1);
-    _port_exp->set_pin_as_output((int)ExtInputPort::ACC_IO_2);
-    _port_exp->set_pin_as_output((int)ExtInputPort::ACC_IO_3);
+    _port_exp->set_pin_as_input((int)ExtInputPort::ACC_IO_1);
+    _port_exp->set_pin_as_input((int)ExtInputPort::ACC_IO_2);
+    _port_exp->set_pin_as_input((int)ExtInputPort::ACC_IO_3);
 }
 
 void CExtInputPortExp::interrupt()
@@ -170,10 +170,13 @@ void CExtInputPortExp::update_led_for_trigger_port(Trigger trigger)
 
 void CExtInputPortExp::update_active_routine()
 {
-    update_active_routine_trigger(ExtInputPort::TRG1_A, trigger_socket::Trigger1, trigger_part::A);
-    update_active_routine_trigger(ExtInputPort::TRG1_B, trigger_socket::Trigger1, trigger_part::B);
-    update_active_routine_trigger(ExtInputPort::TRG2_A, trigger_socket::Trigger2, trigger_part::A);
-    update_active_routine_trigger(ExtInputPort::TRG2_B, trigger_socket::Trigger2, trigger_part::B);
+    update_active_routine_trigger(ExtInputPort::ACC_IO_1, trigger_socket::Acc     , trigger_part::A);
+    update_active_routine_trigger(ExtInputPort::ACC_IO_2, trigger_socket::Acc     , trigger_part::B);
+    update_active_routine_trigger(ExtInputPort::ACC_IO_3, trigger_socket::Acc     , trigger_part::C);
+    update_active_routine_trigger(ExtInputPort::TRG1_A  , trigger_socket::Trigger1, trigger_part::A);
+    update_active_routine_trigger(ExtInputPort::TRG1_B  , trigger_socket::Trigger1, trigger_part::B);
+    update_active_routine_trigger(ExtInputPort::TRG2_A  , trigger_socket::Trigger2, trigger_part::A);
+    update_active_routine_trigger(ExtInputPort::TRG2_B  , trigger_socket::Trigger2, trigger_part::B);
 }
 
 void CExtInputPortExp::update_active_routine_trigger(enum ExtInputPort input, trigger_socket socket, trigger_part part)
@@ -192,19 +195,25 @@ void CExtInputPortExp::update_active_routine_trigger(enum ExtInputPort input, tr
 
 void CExtInputPortExp::reset_acc_port()
 {
-    _port_exp->set_pin_state((int)ExtInputPort::ACC_IO_1, true);
-    _port_exp->set_pin_state((int)ExtInputPort::ACC_IO_2, true);
-    _port_exp->set_pin_state((int)ExtInputPort::ACC_IO_3, true);
+    _port_exp->set_pin_as_input((int)ExtInputPort::ACC_IO_1);
+    _port_exp->set_pin_as_input((int)ExtInputPort::ACC_IO_2);
+    _port_exp->set_pin_as_input((int)ExtInputPort::ACC_IO_3);
 }
 
-void CExtInputPortExp::set_acc_io_port_state(enum ExtInputPort output, bool high)
+void CExtInputPortExp::set_acc_io_port_state(enum ExtInputPort output, ExtInputPortState state)
 {
     switch (output)
     {
         case ExtInputPort::ACC_IO_1:
         case ExtInputPort::ACC_IO_2:
         case ExtInputPort::ACC_IO_3:
-            _port_exp->set_pin_state((int)output, high);
+            if (state == ExtInputPortState::INPUT)
+                _port_exp->set_pin_as_input((int)output);
+            else
+            {
+                _port_exp->set_pin_as_output((int)output);
+                _port_exp->set_pin_state((int)output, state == ExtInputPortState::OUTPUT_HIGH);
+            }
             break;
     }
 }

--- a/source/zc95/PortExpanders/CExtInputPortExp.h
+++ b/source/zc95/PortExpanders/CExtInputPortExp.h
@@ -27,7 +27,7 @@ class CExtInputPortExp
         
         void interrupt();
         void reset_acc_port();
-        void set_acc_io_port_state(enum ExtInputPort output, bool high);
+        void set_acc_io_port_state(enum ExtInputPort output, ExtInputPortState state);
 
     
     private:

--- a/source/zc95/PortExpanders/EExtInputPort.h
+++ b/source/zc95/PortExpanders/EExtInputPort.h
@@ -13,4 +13,11 @@ enum class ExtInputPort
     TRG1_B   = 7
 };
 
+enum class ExtInputPortState
+{
+    OUTPUT_LOW  = 0,
+    OUTPUT_HIGH = 1,
+    INPUT = 3
+};
+
 #endif

--- a/source/zc95/PortExpanders/IPortExpander.h
+++ b/source/zc95/PortExpanders/IPortExpander.h
@@ -11,6 +11,7 @@ class IPortExpander
         virtual bool read_port_expander(uint8_t *value) = 0;
         virtual bool write_port_expander(uint8_t value) = 0;
         virtual bool set_pin_as_output(uint8_t pin) = 0;
+        virtual bool set_pin_as_input(uint8_t pin) = 0;
         virtual bool set_pin_state(uint8_t pin, bool high) = 0;
         virtual bool is_output_pin_set(uint8_t pin) = 0;
         virtual bool get_pin_state(uint8_t pin) = 0;

--- a/source/zc95/PortExpanders/PCF8574.cpp
+++ b/source/zc95/PortExpanders/PCF8574.cpp
@@ -45,6 +45,13 @@ bool PCF8574::set_pin_as_output(uint8_t pin)
     return true;
 }
 
+bool PCF8574::set_pin_as_input(uint8_t pin)
+{
+    // A PCF8574 has no real concept of this (no direction register). You just call set_pin_state.
+    set_pin_state(pin, true);
+    return true;
+}
+
 bool PCF8574::set_pin_state(uint8_t pin, bool high)
 {
     uint8_t new_val = _output_state;

--- a/source/zc95/PortExpanders/PCF8574.h
+++ b/source/zc95/PortExpanders/PCF8574.h
@@ -16,6 +16,7 @@ class PCF8574 : public IPortExpander
         bool read_port_expander(uint8_t *value);
         bool write_port_expander(uint8_t value);
         bool set_pin_as_output(uint8_t pin);
+        bool set_pin_as_input(uint8_t pin);
         bool set_pin_state(uint8_t pin, bool high);
         bool is_output_pin_set(uint8_t pin);
         bool get_pin_state(uint8_t pin);

--- a/source/zc95/PortExpanders/TCA9534.cpp
+++ b/source/zc95/PortExpanders/TCA9534.cpp
@@ -38,6 +38,29 @@ bool TCA9534::set_pin_as_output(uint8_t pin)
     return true;
 }
 
+bool TCA9534::set_pin_as_input(uint8_t pin)
+{
+    uint8_t txbuf[2] = {0};
+
+    txbuf[0] = port_exp_reg_t::CONFIGURATION;
+    txbuf[1] = _config_register;
+    txbuf[1] |= (1 << pin);
+    int bytes_written = i2c_write(__func__, _i2c_address, txbuf, sizeof(txbuf), false);
+    if (bytes_written != 2)
+    {
+        printf("TCA9534::set_pin_as_input() write failed! i2c bytes_written = %d\n", bytes_written);
+        return false;
+    }
+
+    _config_register = txbuf[1];
+    return true;
+}
+
+bool TCA9534::is_pin_configured_as_output(uint8_t pin)
+{
+    return !(_config_register & (1 << pin));
+}
+
 bool TCA9534::read_port_expander(uint8_t *value)
 {
     uint8_t buffer[1] = {0};

--- a/source/zc95/PortExpanders/TCA9534.h
+++ b/source/zc95/PortExpanders/TCA9534.h
@@ -16,6 +16,7 @@ class TCA9534 : public IPortExpander
         bool read_port_expander(uint8_t *value);
         bool write_port_expander(uint8_t value);
         bool set_pin_as_output(uint8_t pin);
+        bool set_pin_as_input(uint8_t pin);
         bool set_pin_state(uint8_t pin, bool high);
         bool is_output_pin_set(uint8_t pin);
         bool get_pin_state(uint8_t pin);
@@ -30,6 +31,7 @@ class TCA9534 : public IPortExpander
         };
 
         void pin_changed(uint8_t pin);
+        bool is_pin_configured_as_output(uint8_t pin);
 
         uint8_t _i2c_address;
 

--- a/source/zc95/core1/CRoutineOutputCore1.cpp
+++ b/source/zc95/core1/CRoutineOutputCore1.cpp
@@ -296,15 +296,15 @@ void CRoutineOutputCore1::process_message(message msg)
         }
 
         case MESSAGE_SET_ACC_IO_PORT1_STATE:
-            set_acc_io_port_state(ExtInputPort::ACC_IO_1, msg.msg8[1]);
+            set_acc_io_port_state(ExtInputPort::ACC_IO_1, (ExtInputPortState)msg.msg8[1]);
             break;
 
         case MESSAGE_SET_ACC_IO_PORT2_STATE:
-            set_acc_io_port_state(ExtInputPort::ACC_IO_2, msg.msg8[1]);
+            set_acc_io_port_state(ExtInputPort::ACC_IO_2, (ExtInputPortState)msg.msg8[1]);
             break;
 
         case MESSAGE_SET_ACC_IO_PORT3_STATE:
-            set_acc_io_port_state(ExtInputPort::ACC_IO_3, msg.msg8[1]);
+            set_acc_io_port_state(ExtInputPort::ACC_IO_3, (ExtInputPortState)msg.msg8[1]);
             break;
 
         case MESSAGE_SET_ACC_IO_PORT_RESET:
@@ -442,10 +442,10 @@ void CRoutineOutputCore1::reset_acc_port()
         _hal->acc_port_reset();
 }
 
-void CRoutineOutputCore1::set_acc_io_port_state(ExtInputPort output, bool high)
+void CRoutineOutputCore1::set_acc_io_port_state(ExtInputPort output, ExtInputPortState state)
 {
     if (_hal)
-        _hal->acc_port_set_io_port_state(output, high);
+        _hal->acc_port_set_io_port_state(output, state);
 }
 
 lua_script_state_t CRoutineOutputCore1::get_lua_script_state()

--- a/source/zc95/core1/CRoutineOutputCore1.h
+++ b/source/zc95/core1/CRoutineOutputCore1.h
@@ -41,7 +41,7 @@ class CRoutineOutputCore1 : public CRoutineOutput
         void audio_intensity_change(uint8_t left_chan, uint8_t right_chan, uint8_t virt_chan = 0);
 
         void reset_acc_port();
-        void set_acc_io_port_state(enum ExtInputPort output, bool high);
+        void set_acc_io_port_state(enum ExtInputPort output, ExtInputPortState state);
         lua_script_state_t get_lua_script_state();
         void set_text_callback_function(std::function<void(pattern_text_output_t)> cb);
         void set_menu_change_callback_function(std::function<void(menu_change_msg_t)> cb);

--- a/source/zc95/core1/routines/CAccPort.cpp
+++ b/source/zc95/core1/routines/CAccPort.cpp
@@ -42,21 +42,21 @@ void CAccPort::reset()
     multicore_fifo_push_blocking(msg.msg32);
 }
 
-void CAccPort::set_io_port_state(enum ExtInputPort output, bool high)
+void CAccPort::set_io_port_state(enum ExtInputPort output, ExtInputPortState state)
 {
-    uint8_t messsge_type = 0;
+    uint8_t message_type = 0;
     switch (output)
     {
-        case ExtInputPort::ACC_IO_1: messsge_type = MESSAGE_SET_ACC_IO_PORT1_STATE; break;
-        case ExtInputPort::ACC_IO_2: messsge_type = MESSAGE_SET_ACC_IO_PORT2_STATE; break;
-        case ExtInputPort::ACC_IO_3: messsge_type = MESSAGE_SET_ACC_IO_PORT3_STATE; break;
+        case ExtInputPort::ACC_IO_1: message_type = MESSAGE_SET_ACC_IO_PORT1_STATE; break;
+        case ExtInputPort::ACC_IO_2: message_type = MESSAGE_SET_ACC_IO_PORT2_STATE; break;
+        case ExtInputPort::ACC_IO_3: message_type = MESSAGE_SET_ACC_IO_PORT3_STATE; break;
         default:
             return;
     }
 
     message msg = {0};
-    msg.msg8[0] = messsge_type;
-    msg.msg8[1] = (uint8_t)high;
+    msg.msg8[0] = message_type;
+    msg.msg8[1] = (uint8_t)state;
     msg.msg8[2] = 0;
     msg.msg8[3] = 0;
 

--- a/source/zc95/core1/routines/CAccPort.h
+++ b/source/zc95/core1/routines/CAccPort.h
@@ -10,7 +10,7 @@ class CAccPort
         ~CAccPort();
         
         void reset();
-        void set_io_port_state(enum ExtInputPort output, bool high);
+        void set_io_port_state(enum ExtInputPort output, ExtInputPortState state);
 
     private:
 

--- a/source/zc95/core1/routines/CBuzz.cpp
+++ b/source/zc95/core1/routines/CBuzz.cpp
@@ -163,9 +163,6 @@ void CBuzz::trigger(trigger_socket socket, trigger_part part, bool active)
     if (!_game_running)
         return;
 
-    if (socket != trigger_socket::Trigger1)
-        return;
-
     // Part A = Handle touching end. Make sure the signal is present for at least x milliseconds to avoid false triggering
     if (part == trigger_part::A)
     {

--- a/source/zc95/core1/routines/CCamTrigger.cpp
+++ b/source/zc95/core1/routines/CCamTrigger.cpp
@@ -114,6 +114,7 @@ void CCamTrigger::soft_button_pushed (soft_button button, bool pushed)
 
 void CCamTrigger::start()
 {
+    acc_port.set_io_port_state(ExtInputPort::ACC_IO_1, ExtInputPortState::OUTPUT_HIGH);
     set_all_channels_power(POWER_FULL);
 }
 
@@ -130,13 +131,13 @@ void CCamTrigger::loop(uint64_t time_us)
     {
         _cam_pulse_start_us = 0;
         _cam_pulse_end_us = time_us + (DefaultCamPulseMs * 1000);
-        acc_port.set_io_port_state(ExtInputPort::ACC_IO_1, 0);
+        acc_port.set_io_port_state(ExtInputPort::ACC_IO_1, ExtInputPortState::OUTPUT_LOW);
     }
 
     if (_cam_pulse_end_us && (time_us > _cam_pulse_end_us))
     {
         _cam_pulse_end_us = 0;
-        acc_port.set_io_port_state(ExtInputPort::ACC_IO_1, 1);
+        acc_port.set_io_port_state(ExtInputPort::ACC_IO_1, ExtInputPortState::OUTPUT_HIGH);
     }
 }
 

--- a/source/zc95/core1/routines/CFire.cpp
+++ b/source/zc95/core1/routines/CFire.cpp
@@ -111,7 +111,7 @@ void CFire::soft_button_pushed (soft_button button, bool pushed)
         }
         else
         {
-            // Continous mode (on whilst button held down)
+            // Continuous mode (on whilst button held down)
             if (pushed)
                 all_channels(true);
             else

--- a/source/zc95/core1/routines/CLuaRoutine.cpp
+++ b/source/zc95/core1/routines/CLuaRoutine.cpp
@@ -112,6 +112,7 @@ void CLuaRoutine::load_lua_script_if_required()
             { "SetFrequency"  , &dispatch<&CLuaRoutine::lua_set_freq> },
             { "SetPulseWidth" , &dispatch<&CLuaRoutine::lua_set_pulse_width> },
             { "AccIoWrite"    , &dispatch<&CLuaRoutine::lua_acc_io_write> },
+            { "AccIoSetInput" , &dispatch<&CLuaRoutine::lua_acc_io_input> },
             { "EnableTriphase", &dispatch<&CLuaRoutine::lua_enable_triphase> },
             { "LinkChannels"  , &dispatch<&CLuaRoutine::lua_link_channel> },
             { "DelayMs"       , &dispatch<&CLuaRoutine::lua_delay_ms> },
@@ -330,6 +331,10 @@ void CLuaRoutine::trigger(trigger_socket socket, trigger_part part, bool active)
         case trigger_socket::Trigger2:
             str_socket = "TRIGGER2";
             break;
+        
+        case trigger_socket::Acc:
+            str_socket = "ACCESSORY";
+            break;
 
         default:
             printf("CLuaRoutine::trigger: Error, unexpected trigger socket: %d\n", (int)socket);
@@ -344,6 +349,10 @@ void CLuaRoutine::trigger(trigger_socket socket, trigger_part part, bool active)
 
         case trigger_part::B:
             str_part = "B";
+            break;
+        
+        case trigger_part::C: // only applicable for the accessory port, which has 3 lines
+            str_part = "C";
             break;
 
         default:
@@ -867,10 +876,35 @@ int CLuaRoutine::lua_acc_io_write(lua_State *L)
             return 0;
     }
 
-    acc_port.set_io_port_state(io_port, state);
+    if (state)
+        acc_port.set_io_port_state(io_port, ExtInputPortState::OUTPUT_HIGH);
+    else
+        acc_port.set_io_port_state(io_port, ExtInputPortState::OUTPUT_LOW);
 
     return 1;
 }
+
+// Params:
+// int : Accessory port I/O line (1-3) to set to input mode
+int CLuaRoutine::lua_acc_io_input(lua_State *L)
+{
+    int io_line = lua_tointeger(L, 1);
+
+    ExtInputPort io_port;
+    switch (io_line)
+    {
+        case 1: io_port = ExtInputPort::ACC_IO_1; break;
+        case 2: io_port = ExtInputPort::ACC_IO_2; break;
+        case 3: io_port = ExtInputPort::ACC_IO_3; break;
+        default:
+            return 0;
+    }
+
+    acc_port.set_io_port_state(io_port, ExtInputPortState::INPUT);
+
+    return 1;
+}
+
 
 // Params:
 // bool: State - true=enabled, false=disabled

--- a/source/zc95/core1/routines/CLuaRoutine.h
+++ b/source/zc95/core1/routines/CLuaRoutine.h
@@ -67,6 +67,7 @@ class CLuaRoutine: public CRoutine
         int lua_set_freq(lua_State *L);
         int lua_set_pulse_width(lua_State *L);
         int lua_acc_io_write(lua_State *L);
+        int lua_acc_io_input(lua_State *L);
         int lua_enable_triphase(lua_State *L);
         int lua_link_channel(lua_State *L);
         int lua_delay_ms(lua_State *L);

--- a/source/zc95/core1/routines/CRoutine.h
+++ b/source/zc95/core1/routines/CRoutine.h
@@ -35,13 +35,15 @@ enum class menu_entry_type
 enum class trigger_socket
 {
     Trigger1,
-    Trigger2
+    Trigger2,
+    Acc
 };
 
 enum class trigger_part
 {
     A,
-    B
+    B,
+    C
 };
 
 enum class soft_button


### PR DESCRIPTION
Allow the three I/O lines on the accessory port to be used as inputs, in a similar way to the trigger sockets. 
These already allowed output via Lua.