### PR TITLE
fix extended ramp when ramp shape is non-zero, and start is not 1%

### DIFF
--- a/source/zc95/core1/CPowerLevelRamp.cpp
+++ b/source/zc95/core1/CPowerLevelRamp.cpp
@@ -31,8 +31,15 @@ float CPowerLevelRamp::get_ramp_power_percent()
         return 100;
 
     float shape = (float)_saved_settings->get_extended_ramp_shape() / (float)10;
-    float shape_adjusted_ramp = s_normalized_exponential(shape, _ramp_percent / (float)100);
-    return shape_adjusted_ramp * 100;
+    if (shape == 0)
+        return _ramp_percent;
+
+    // s_normalized_exponential needs to see a % between 0 - 100, regradless of what the start point was.
+    float shape_adjusted_ramp = s_normalized_exponential(shape, get_ramp_progress_percent() / (float)100);
+
+    // generate output percent
+    float ramp_up_portion = 100 - _saved_settings->get_extended_ramp_level(); // get_extended_ramp_level returns the configured start of ramp as a %
+    return _saved_settings->get_extended_ramp_level() + (ramp_up_portion * shape_adjusted_ramp);
 }
 
 float CPowerLevelRamp::get_ramp_progress_percent()

--- a/source/zc95/core1/CPowerLevelRamp.h
+++ b/source/zc95/core1/CPowerLevelRamp.h
@@ -22,7 +22,7 @@ class CPowerLevelRamp
     private:
         void calc_ramp_percent();
 
-        float  _ramp_percent = 0; // 100=full power
+        float  _ramp_percent = 0; // 100=full power. This starts at whatever percentage is returned by get_extended_ramp_level (i.e. the user configured starting level), and ends at 100 when the ramp completes.
         bool _ramp_in_progress = false;
         uint64_t _ramp_start_time_us = 0;
         uint64_t _last_calc_us = 0;


### PR DESCRIPTION
Closes #180 