### PR TITLE
set input current limit much earlier

### DIFF
--- a/source/zc95/CSavedSettings.cpp
+++ b/source/zc95/CSavedSettings.cpp
@@ -43,6 +43,16 @@ CSavedSettings::CSavedSettings(CEeprom *eeprom)
     for (int n=0; n < EEPROM_SIZE; n++)
         _eeprom_contents[n] = _eeprom->read(n);
     printf("done\n");
+
+    if (_eeprom_contents[(uint16_t)setting::EepromInit] != EEPROM_MAGIC_VAL)
+    {
+        // This should only be reachable if the EEPROM isn't working (not found, faulty, whatever).
+        // Re-populate _eeprom_contents with defaults, which the "Read eeprom..." step 
+        // above will have effectively wiped if there was an error reading the EEPROM
+        eeprom_initialise(); 
+        
+        printf("Failed to initialise EEPROM\n");
+    }
 }
 
 CSavedSettings::~CSavedSettings()

--- a/source/zc95/Hal/HalMk2.cpp
+++ b/source/zc95/Hal/HalMk2.cpp
@@ -1,5 +1,6 @@
 #include "pico/stdlib.h"
 #include "hardware/pwm.h"
+#include "hardware/adc.h"
 #include "HalMk2.h"
 #include "../HwCheck/CDetermineHardwareVersion.h"
 #include "../FrontPanel/CFrontPanelV02.h"
@@ -50,6 +51,10 @@ HalMk2::HalMk2(CLedControl* led, CRoutineOutput** routine_output, CAnalogueCaptu
 
     // Reset LCD
     _main_board_port_exp->lcd_reset();
+
+    // On startup, get some inital values for the voltage at the USB CC lines
+    if (!_analogue_capture->is_running() && _variant == hw_variant_t::V2_2)
+        get_inital_usb_cc_values();
 }
 
 HalMk2::~HalMk2()
@@ -202,4 +207,27 @@ front_panel_version_t HalMk2::front_panel_version()
 CLedControl* HalMk2::led_control()
 {
     return _led;
+}
+
+void HalMk2::get_inital_usb_cc_values()
+{
+    if (_variant != hw_variant_t::V2_2)
+        return;
+
+    adc_init();
+    adc_gpio_init(26);
+    adc_select_input(0);
+
+    const float conversion_factor_to_mv = 3300.0f / (1 << 12);
+
+    _main_board_port_exp->set_adc0_source(CMainBoardPortExp::adc0_select_t::USB_CC1);
+    sleep_ms(10);
+    uint16_t cc1 = adc_read();
+
+
+    _main_board_port_exp->set_adc0_source(CMainBoardPortExp::adc0_select_t::USB_CC2);
+    sleep_ms(10);
+    uint16_t cc2 = adc_read();
+
+    _mk2_pm->set_inital_cc_voltages_and_set_input_current_limit(conversion_factor_to_mv * cc1, conversion_factor_to_mv * cc2);
 }

--- a/source/zc95/Hal/HalMk2.h
+++ b/source/zc95/Hal/HalMk2.h
@@ -40,6 +40,7 @@ class HalMk2 : public IHal
         void set_mkII_variant();
         void set_display_brightness();
         void init_pwm_pin(uint8_t gpio);
+        void get_inital_usb_cc_values();
         hw_variant_t _variant;
         
         TCA9534* _tca9534_ext = NULL;

--- a/source/zc95/PowerManagement/CPowerManagementMk2.cpp
+++ b/source/zc95/PowerManagement/CPowerManagementMk2.cpp
@@ -155,6 +155,13 @@ void CPowerManagementMk2::add_raw_adc_readings(const uint8_t *raw_adc_readings_b
     }
 }
 
+void CPowerManagementMk2::set_inital_cc_voltages_and_set_input_current_limit(int16_t cc1_mv, int16_t cc2_mv)
+{
+    _usb_power.set_cc1_voltage_mV(cc1_mv);
+    _usb_power.set_cc2_voltage_mV(cc2_mv);
+    _usb_power.update_input_current_limit(true);
+}
+
 int CPowerManagementMk2::s_cmpfunc (const void *a, const void *b)
 {
    return ( *(uint32_t*)a - *(uint32_t*)b );

--- a/source/zc95/PowerManagement/CPowerManagementMk2.h
+++ b/source/zc95/PowerManagement/CPowerManagementMk2.h
@@ -27,6 +27,7 @@ class CPowerManagementMk2 : public IPowerManagement
         uint8_t get_battery_percentage();
 
         void add_raw_adc_readings(const uint8_t *raw_adc_readings_buffer, uint8_t buffer_array_len);
+        void set_inital_cc_voltages_and_set_input_current_limit(int16_t cc1_mv, int16_t cc2_mv);
 
     private:
         static int s_cmpfunc (const void *a, const void *b);

--- a/source/zc95/PowerManagement/CUsbPower.cpp
+++ b/source/zc95/PowerManagement/CUsbPower.cpp
@@ -34,8 +34,7 @@ void CUsbPower::loop()
     if (!_active)
         return;
 
-    update_usb_power_status();
-    update_input_current_limit();
+    update_input_current_limit(false);
     set_charge_current();
 
     _charge_ctl.read_register(BQ25601_REG00);
@@ -101,9 +100,11 @@ void CUsbPower::update_usb_power_status()
     }
 }
 
-void CUsbPower::update_input_current_limit()
+void CUsbPower::update_input_current_limit(bool force_update)
 {
-    if (_time_usb_power_changed && (time_us_64() - _time_usb_power_changed) > SecondsInUs(5))
+    update_usb_power_status();
+
+    if (force_update || (_time_usb_power_changed && (time_us_64() - _time_usb_power_changed) > SecondsInUs(2)))
     {
         uint16_t limit = get_current_limit_ma(_usb_power);
         _charge_ctl.set_input_current_limit_mA(limit);
@@ -111,7 +112,6 @@ void CUsbPower::update_input_current_limit()
         _time_usb_power_changed = 0;
     }
 }
-
 
 // Use the voltage on the USB CC pins to figure out what type of charger is attached.
 // Can be fooled by dubious cables.

--- a/source/zc95/PowerManagement/CUsbPower.h
+++ b/source/zc95/PowerManagement/CUsbPower.h
@@ -15,6 +15,7 @@ class CUsbPower
         CUsbPower(hw_variant_t variant);
         void set_cc1_voltage_mV(int16_t mv);
         void set_cc2_voltage_mV(int16_t mv);
+        void update_input_current_limit(bool force_update);
         bool ext_power_good();
         BQ25601::charge_status_enum charge_status();
         void loop();
@@ -31,7 +32,6 @@ class CUsbPower
         usb_power_t get_usb_power();
         std::string usb_power_status_string(usb_power_t usb_power_status);
         void update_usb_power_status();
-        void update_input_current_limit();
         uint16_t get_current_limit_ma(usb_power_t usb);
         void set_charge_current();
         constexpr time_us_t SecondsInUs(int seconds) { return (seconds * 1000000); }

--- a/source/zc95/zc95.cpp
+++ b/source/zc95/zc95.cpp
@@ -191,11 +191,18 @@ int main()
     
     // Serial on acc port
     gpio_set_function(PIN_ACC_UART_TX, GPIO_FUNC_UART);
-    gpio_set_function(PIN_ACC_UART_RX, GPIO_FUNC_UART);    
-    
+    gpio_set_function(PIN_ACC_UART_RX, GPIO_FUNC_UART);
+
     // For now, until settings loaded from eeprom, send debugging info to accessory port
     CDebugOutput::set_debug_destination(CDebugOutput::debug_dest_t::ACC);
     printf("\n\nZC95 Startup, firmware version: %s\n", firmware_info.firmware_version);
+
+    sleep_ms(100); // wait for eeprom to be ready
+    settings = new CSavedSettings(&eeprom);
+    g_SavedSettings = settings;
+    
+    // Now settings have (hopefully!) been loaded, set debug output as per stored config
+    CDebugOutput::set_debug_destination_from_settings(settings);   
     
     zc95_version_t hardware_version = CDetermineHardwareVersion::get_hardware_version();
 
@@ -229,15 +236,8 @@ int main()
     // Make sure there is some semi-random-ish data available
     seed_random_from_rosc();
 
-    // Note eeprom ic is on i2c bus
-    sleep_ms(100); // wait for eeprom to be ready
-    settings = new CSavedSettings(&eeprom);
-    g_SavedSettings = settings;
-
     // Configure AUX port for serial or audio use
     _hal->audio_input_enable(settings->get_aux_port_use() == CSavedSettings::setting_aux_port_use::AUDIO);
-
-    CDebugOutput::set_debug_destination_from_settings(settings);
 
     // Front panel LEDs - update brightness now saved settings are available
     led.set_all_led_colour(LedColour::Purple);


### PR DESCRIPTION
Set the input current limit - based on the connected charger (if any) - much earlier in the boot process than before. Should reduce the probably of issues due to lack of power if the battery is either completely flat, or missing. 

The zc95 is still not intended to be used without a battery installed.
