### PR TITLE
Allow display of battery voltage in battery icon

### DIFF
--- a/docs/Operation.md
+++ b/docs/Operation.md
@@ -83,6 +83,8 @@ Configuration options so far:
     - In bar graph - Show value, rotated 90 degrees, inside the corresponding bar graph
     - Both - Enable Disappearing text display and in bar graph
 
+  - Battery status - Controls what is displayed in the battery icon: Percentage (default) or voltage
+
   - Button brightness - controls how bright the LEDs in the 4 front panel buttons are
 
   - MKII only: Display brightness - as you would expect, changes the display brightness

--- a/source/zc95/CMakeLists.txt
+++ b/source/zc95/CMakeLists.txt
@@ -133,6 +133,7 @@ add_executable(zc95
   display/config/display_options/CMenuSettingDisplayOptions.cpp
   display/config/display_options/CMenuSettingButtonBrightness.cpp
   display/config/display_options/CMenuSettingPowerLevelDisplay.cpp
+  display/config/display_options/CMenuSettingBatteryStatus.cpp
   display/config/display_options/CMenuSettingLedBrightnes.cpp
   display/config/display_options/CMenuSettingsStatusBarText.cpp
   display/config/display_options/CMenuSettingDisplayBrightness.cpp

--- a/source/zc95/CSavedSettings.cpp
+++ b/source/zc95/CSavedSettings.cpp
@@ -533,6 +533,16 @@ void CSavedSettings::set_status_bar_option(status_bar_text_t status_bar_option)
     _eeprom_contents[(uint8_t)setting::StatusBarOption] = (uint8_t)status_bar_option;
 }
 
+CSavedSettings::battery_status_t CSavedSettings::get_battery_status()
+{
+    return (battery_status_t)(_eeprom_contents[(uint8_t)setting::BatteryStatus]);
+}
+
+void CSavedSettings::set_battery_status(battery_status_t battery_status)
+{
+    _eeprom_contents[(uint8_t)setting::BatteryStatus] = (uint8_t)battery_status;
+}
+
 uint8_t CSavedSettings::get_display_brightness_percent()
 {
     uint8_t percent = (_eeprom_contents[(uint8_t)setting::DisplayBrightness]);
@@ -695,6 +705,7 @@ void CSavedSettings::eeprom_initialise()
     _eeprom_contents[(uint8_t)setting::ButtonLedBright] = 10;
     _eeprom_contents[(uint8_t)setting::BatChargeCurrent] = 25; // 25 * 60 = 1500 mA
     _eeprom_contents[(uint8_t)setting::StatusBarOption]  = (uint8_t)status_bar_text_t::RUNNING_PATTERN;
+    _eeprom_contents[(uint8_t)setting::BatteryStatus]    = (uint8_t)battery_status_t::PERCENTAGE;
 
     _eeprom_contents[(uint8_t)setting::ExtendedRampLevel] = 70;
     _eeprom_contents[(uint8_t)setting::ExtenedRampTime] = 20;

--- a/source/zc95/CSavedSettings.h
+++ b/source/zc95/CSavedSettings.h
@@ -75,7 +75,8 @@ class CSavedSettings
         ExtendedRampShow = 230, // Show 'Ramp start' option on all patterns, and should progress be displayed on the status bar
         LedColourFormat  = 231, // Colour format (RBG, BGR, etc) of front panel LED buttons
         BootloaderMode   = EEPROM_BOOTLOADER_SETTING_ADDR, // (232) What the bootloader should do on next startup. Added as #define as it's shared with the bootloader code
-        ExtenedRampShape = 233
+        ExtenedRampShape = 233,
+        BatteryStatus    = 234  // What to show inside the battery status icon
     };
 
     public:
@@ -146,6 +147,12 @@ class CSavedSettings
         {
             RUNNING_PATTERN = 0,
             BATTERY_CURRENT = 1
+        };
+
+        enum class battery_status_t
+        {
+            PERCENTAGE = 0,
+            VOLTAGE    = 1
         };
 
         enum class led_colour_format_t
@@ -275,6 +282,9 @@ class CSavedSettings
 
         status_bar_text_t get_status_bar_option();
         void set_status_bar_option(status_bar_text_t status_bar_option);
+
+        battery_status_t get_battery_status();
+        void set_battery_status(battery_status_t battery_status);
 
         uint8_t get_display_brightness_percent();
         void set_display_brightness_percent(uint8_t percent);

--- a/source/zc95/display/CDisplay.cpp
+++ b/source/zc95/display/CDisplay.cpp
@@ -314,8 +314,6 @@ void CDisplay::draw_bar(uint8_t bar_number, std::string label, uint16_t max_powe
 
 void CDisplay::draw_status_bar()
 {
-    char buffer[100] = {0};
-
     battery_state_t state;
     IPowerManagement::power_status_t power_status = _power_management->power_status();
     if (power_status == IPowerManagement::power_status_t::OnBattery)
@@ -333,20 +331,12 @@ void CDisplay::draw_status_bar()
     if (_power_management->get_battery_percentage() == 0xFF || _power_management->power_status() == IPowerManagement::power_status_t::Unknown)
         state = battery_state_t::Fault;
 
-    // Draw battery percent with icon
+    // Draw battery status (percentage or voltage) with icon
     uint16_t y = (MIPI_DISPLAY_HEIGHT-1) - status_bar_height+2;
     draw_battery_icon(0, y, state);
-    if (state == battery_state_t::Fault)
-    {
-        // Can't figure out what's going on with the battery (maybe it's missing?)...
-        snprintf(buffer, sizeof(buffer)-1, "?");
-    }
-    else
-    {
-        snprintf(buffer, sizeof(buffer)-1, "%d", _power_management->get_battery_percentage());
-    }
 
-    put_text(buffer, 4, y, hagl_color(_hagl_backend, 0xAA, 0xAA, 0xAA), false, font5x7);
+    std::string battery_text = get_battery_status_text(state);
+    put_text(battery_text, get_battery_status_text_x(battery_text), y, hagl_color(_hagl_backend, 0xAA, 0xAA, 0xAA), false, font5x7);
 
     // Status text: either running pattern, battery current draw or ramp progress
     std::string status_text = get_status_bar_text();
@@ -407,6 +397,63 @@ std::string CDisplay::get_status_bar_text()
     }
 
     return status_text;
+}
+
+// Get the string to put inside the battery icon. Either voltage or percentage - config
+// dependant - if things are working. Or "?" if there's some kind of issue
+std::string CDisplay::get_battery_status_text(battery_state_t state)
+{
+    char battery_text[8] = {0};
+
+    if (state == battery_state_t::Fault)
+    {
+        // Can't figure out what's going on with the battery (maybe it's missing?)...
+        snprintf(battery_text, sizeof(battery_text)-1, "?");
+        return battery_text;
+    }
+
+    if (g_SavedSettings->get_battery_status() == CSavedSettings::battery_status_t::VOLTAGE)
+    {
+        int16_t battery_voltage_mV = 0;
+        if (!_power_management->get_stat(&battery_voltage_mV, IPowerManagement::power_stat_t::BatVoltage) || battery_voltage_mV < 0)
+        {
+            snprintf(battery_text, sizeof(battery_text)-1, "?");
+            return battery_text;
+        }
+
+        // When voltage is >= 10v (applies to mk1's), show "nn.n"
+        if (battery_voltage_mV >= 10000)
+        {
+            uint16_t decivolts = (battery_voltage_mV + 50) / 100;
+            snprintf(battery_text, sizeof(battery_text)-1, "%d.%d", decivolts / 10, decivolts % 10);
+        }
+
+        // When voltage is < 10v (applies to mk2's), show "n.nn"
+        else
+        {
+            uint16_t centivolts = (battery_voltage_mV + 5) / 10;
+            snprintf(battery_text, sizeof(battery_text)-1, "%d.%02d", centivolts / 100, centivolts % 100);
+        }
+    }
+    else
+    {
+        snprintf(battery_text, sizeof(battery_text)-1, "%d", _power_management->get_battery_percentage());
+    }
+
+    return battery_text;
+}
+
+// Determine whereabouts the text in the battery icon should start
+int16_t CDisplay::get_battery_status_text_x(std::string text)
+{
+    const int16_t battery_icon_width = 24;
+    const int16_t font5x7_width = 5;
+    int16_t text_width = text.length() * font5x7_width;
+
+    if (text_width >= battery_icon_width)
+        return 0;
+
+    return (battery_icon_width - text_width) / 2;
 }
 
 void CDisplay::draw_power_level_indicator(int16_t x, int16_t y)
@@ -481,7 +528,10 @@ void CDisplay::draw_battery_icon(int16_t x, int16_t y, battery_state_t state)
 
             for (uint8_t sec = 0; sec < 3; sec++)
             {
-                draw_logo(bat_logo_filled[sec], x + (sec * 8), y-1, colour);
+                if (g_SavedSettings->get_battery_status() == CSavedSettings::battery_status_t::VOLTAGE)
+                    draw_logo(bat_logo[sec], x + (sec * 8), y-1, colour); // the filled logo doesn't look right when showing voltage, as the voltage takes up too much space
+                else
+                    draw_logo(bat_logo_filled[sec], x + (sec * 8), y-1, colour);
             }
         }
         break;
@@ -686,4 +736,3 @@ void CDisplay::show_splash_screen()
 
     hagl_flush(_hagl_backend);
 }
-

--- a/source/zc95/display/CDisplay.h
+++ b/source/zc95/display/CDisplay.h
@@ -80,6 +80,8 @@ class CDisplay
         void draw_logo(const uint8_t logo[9], int16_t x0, int16_t y0, hagl_color_t colour);
         void draw_bt_logo_if_required(int16_t x, int16_t y);
         void draw_battery_icon(int16_t x, int16_t y, battery_state_t state);
+        std::string get_battery_status_text(battery_state_t state);
+        int16_t get_battery_status_text_x(std::string text);
         void draw_power_level_indicator(int16_t x, int16_t y);
 
         // Soft buttons

--- a/source/zc95/display/config/display_options/CMenuSettingBatteryStatus.cpp
+++ b/source/zc95/display/config/display_options/CMenuSettingBatteryStatus.cpp
@@ -1,0 +1,129 @@
+/*
+ * ZC95
+ * Copyright (C) 2026  CrashOverride85
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include "CMenuSettingBatteryStatus.h"
+#include "../CMenuSettings.h"
+#include "../../../CDebugOutput.h"
+#include "../../../common/zc95_config.h"
+
+CMenuSettingBatteryStatus::CMenuSettingBatteryStatus(CDisplay* display, CSavedSettings *saved_settings)
+{
+    printf("CMenuSettingBatteryStatus()\n");
+    _display = display;
+    _saved_settings = saved_settings;
+
+    _exit_menu = false;
+
+    _setting_choice_area = display->get_display_area();
+    _setting_choice_area.y0 = _setting_choice_area.y1 - ((_setting_choice_area.y1-_setting_choice_area.y0)/2);
+    _settings_choice_list = new COptionsList(display, _setting_choice_area);
+}
+
+CMenuSettingBatteryStatus::~CMenuSettingBatteryStatus()
+{
+    printf("~CMenuSettingBatteryStatus()\n");
+
+    if (_submenu_active)
+    {
+        delete _submenu_active;
+        _submenu_active = NULL;
+    }
+
+    if (_settings_choice_list)
+    {
+        delete _settings_choice_list;
+        _settings_choice_list = NULL;
+    }
+}
+
+void CMenuSettingBatteryStatus::button_pressed(Button button)
+{
+    if (_submenu_active)
+    {
+        _submenu_active->button_pressed(button);
+    }
+    else
+    {
+        if (button == Button::B) // "Back"
+        {
+            _exit_menu = true;
+        }
+    }
+}
+
+void CMenuSettingBatteryStatus::adjust_rotary_encoder_change(int8_t change)
+{
+    if (_submenu_active)
+    {
+        _submenu_active->adjust_rotary_encoder_change(change);
+    }
+    else
+    {
+        if (change >= 1)
+        {
+            _settings_choice_list->down();
+        }
+        else if (change <= -1)
+        {
+            _settings_choice_list->up();
+        }
+
+        save_setting();
+    }
+}
+
+void CMenuSettingBatteryStatus::save_setting()
+{
+    _saved_settings->set_battery_status((CSavedSettings::battery_status_t)_settings_choice_list->get_current_selection_id());
+}
+
+void CMenuSettingBatteryStatus::draw()
+{
+    display_area disp_area = _display->get_display_area();
+    _display->put_text("Battery status", disp_area.x0+2, disp_area.y0 + 10, hagl_color(_display->get_hagl_backed(), 0xFF, 0xFF, 0xFF));
+
+    hagl_color_t rect_colour = hagl_color(_display->get_hagl_backed(), 0x00, 0x00, 0xFF);
+
+    hagl_fill_rectangle(_display->get_hagl_backed(), _setting_choice_area.x0, _setting_choice_area.y0,
+                        _setting_choice_area.x1, _setting_choice_area.y1, rect_colour);
+
+    _settings_choice_list->draw();
+}
+
+void CMenuSettingBatteryStatus::show()
+{
+    _display->set_option_a("");
+    _display->set_option_b("Back");
+    _display->set_option_c("");
+    _display->set_option_d("");
+
+    _exit_menu = false;
+    set_options_on_multi_choice_list();
+}
+
+void CMenuSettingBatteryStatus::set_options_on_multi_choice_list()
+{
+    _settings_choice_list->clear_options();
+
+    _settings_choice_list->add_option("Percentage", (uint8_t)CSavedSettings::battery_status_t::PERCENTAGE);
+    _settings_choice_list->add_option("Voltage", (uint8_t)CSavedSettings::battery_status_t::VOLTAGE);
+
+    uint8_t current_choice_id = (uint8_t)_saved_settings->get_battery_status();
+
+    _settings_choice_list->set_selected_by_id(current_choice_id);
+}

--- a/source/zc95/display/config/display_options/CMenuSettingBatteryStatus.h
+++ b/source/zc95/display/config/display_options/CMenuSettingBatteryStatus.h
@@ -1,0 +1,27 @@
+#include "../../CMenu.h"
+#include "../../CDisplay.h"
+#include "../../COptionsList.h"
+#include "../../../CSavedSettings.h"
+
+class CMenuSettingBatteryStatus : public CMenu
+{
+    public:
+        CMenuSettingBatteryStatus(CDisplay* display, CSavedSettings *saved_settings);
+        ~CMenuSettingBatteryStatus();
+        void button_pressed(Button button);
+        void adjust_rotary_encoder_change(int8_t change);
+        void draw();
+        void show();
+
+    private:
+        COptionsList *_settings_choice_list = NULL;
+
+        void set_options_on_multi_choice_list();
+        void save_setting();
+
+        struct display_area _area;
+        CDisplay* _display;
+        CGetButtonState *_buttons;
+        display_area _setting_choice_area;
+        CSavedSettings *_saved_settings;
+};

--- a/source/zc95/display/config/display_options/CMenuSettingDisplayOptions.cpp
+++ b/source/zc95/display/config/display_options/CMenuSettingDisplayOptions.cpp
@@ -22,6 +22,7 @@
 #include "CMenuSettingButtonBrightness.h"
 #include "CMenuSettingsStatusBarText.h"
 #include "CMenuSettingDisplayBrightness.h"
+#include "CMenuSettingBatteryStatus.h"
 
 CMenuSettingDisplayOptions::CMenuSettingDisplayOptions(
         CDisplay* display, 
@@ -107,6 +108,10 @@ void CMenuSettingDisplayOptions::show_selected_setting()
         case setting_id::DISPLAY_BRIGHTNESS:
             set_active_menu(new CMenuSettingDisplayBrightness(_display, _saved_settings));
             break;
+
+        case setting_id::BATTERY_STATUS:
+            set_active_menu(new CMenuSettingBatteryStatus(_display, _saved_settings));
+            break;
     }
 }
 
@@ -144,6 +149,7 @@ void CMenuSettingDisplayOptions::show()
 
     _settings.push_back(CMenuSettingDisplayOptions::setting(setting_id::LED_BRIGHTNESS,      "LED brightness     "));
     _settings.push_back(CMenuSettingDisplayOptions::setting(setting_id::POWER_LEVEL_DISPLAY, "Power level display"));
+    _settings.push_back(CMenuSettingDisplayOptions::setting(setting_id::BATTERY_STATUS,      "Battery status     "));
 
     // Illuminated buttons were added for v0.2 of front panel
     if (_hal->front_panel()->verion() == front_panel_version_t::v0_2)

--- a/source/zc95/display/config/display_options/CMenuSettingDisplayOptions.h
+++ b/source/zc95/display/config/display_options/CMenuSettingDisplayOptions.h
@@ -40,7 +40,8 @@ class CMenuSettingDisplayOptions : public CMenu
             POWER_LEVEL_DISPLAY = 1,
             BUTTON_BRIGHTNESS   = 2,
             STATUS_BAR_TEXT     = 3,
-            DISPLAY_BRIGHTNESS  = 4
+            DISPLAY_BRIGHTNESS  = 4,
+            BATTERY_STATUS      = 5
         };
 
         std::vector<setting> _settings;


### PR DESCRIPTION
Adds option to show battery voltage instead of battery percentage inside the battery icon. Default is percentage. 