### PR TITLE
Add mobile-first web GUI for remote pattern control

### DIFF
--- a/docs/RemoteAccess.md
+++ b/docs/RemoteAccess.md
@@ -14,7 +14,7 @@ The remote access options can be used to:
 ## Connecting using WiFi
 If a Pico-W is used, the Config -> Remote Access menu should include options relating to WiFi.
 
-At present, other than the initial WiFi setup, there is no web interface (yet) - all control is via python scripts ran on a PC.
+Once connected to WiFi, patterns can be controlled either using the python scripts below ran on a PC, or using the mobile-friendly web interface (`webgui.py`, see below) from any device on the same network - e.g. a phone.
 
 The basic process is use the "Config Wifi/AP mode" option, ideally connect to the ZC95 using a phone, then use the web interface to enter a WiFi SSID/Password. When the "Connect to Wifi" option is next used, these credentials will be used. At present, other than setting the WiFi SSID/password, nothing else can be done in ap mode.
 
@@ -84,9 +84,10 @@ There are a few Python scripts available in the `remote_access` folder for inter
 * pattern_list.py - lists all patterns available remotely, along with the ID number (excludes Audio patterns)
 * lua_manage.py - lists uploaded Lua scripts, and allows for them to be deleted
 * lua_upload.py - uploads a Lua script
-* pattern_gui.py - starts a GUI that starts a pattern and can then be used to control it
+* pattern_gui.py - starts a tkinter GUI that starts a pattern and can then be used to control it
+* webgui.py - starts a web server providing a mobile-friendly version of pattern_gui.py, so a pattern can be started and controlled from a phone/tablet browser (or several at once) instead
 
-For all scripts:
+For all scripts other than webgui.py (see its own section below):
 * Either ``--ip <IP address>`` _or_ ``--serial <serial port>`` must be specified
 * The optional `--debug` parameter can be used to show messages being sent/received, and sometimes other extra info
 
@@ -171,6 +172,23 @@ See [Lua](./LuaNotes.md) for notes on writing Lua scripts.
 ### pattern_gui.py
 See next section for more details on running a pattern remotely. 
 
+### webgui.py
+Starts a small local web server providing a mobile-friendly equivalent of pattern_gui.py - the pattern to run is picked from a dropdown in the browser rather than passed on the command line, and any number of devices/tabs on the same network can connect at once, all controlling (and seeing the state of) the same running pattern.
+
+Needs a couple of extra dependencies beyond the other scripts here:
+```
+$ pip3 install -r requirements-webgui.txt
+```
+
+Start it pointed at the ZC95's IP (serial isn't supported - a web interface reachable from a phone implies WiFi):
+```
+$ python3 webgui.py --ip 192.168.1.137
+Starting web interface - browse to http://<ip of this machine>:8080/ from your phone/tablet/PC
+```
+
+Then, from any device on the same network (e.g. a phone), browse to `http://<ip of the PC running webgui.py>:8080/`. Use `--port` to change the port it listens on, and `--debug` to log messages sent/received to/from the ZC95 to the console.
+
+See the next section for more on the power sliders/dials, which apply the same way here as with pattern_gui.py.
 
 ## Running a pattern remotely
 

--- a/remote_access/.gitignore
+++ b/remote_access/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.venv/

--- a/remote_access/lib/WebHub.py
+++ b/remote_access/lib/WebHub.py
@@ -26,12 +26,19 @@ class WebHub:
 
     self._clients = set()
 
-    # Last known state, sent to newly (re)connected browser clients so they sync up
+    # Last known state, sent to newly (re)connected browser clients so they sync up.
+    # The ZC95 itself doesn't echo back PatternMinMaxChange/PatternMultiChoiceChange/SetPower
+    # to other connections, so this hub is what keeps multiple browser tabs/devices in sync
+    # with each other, not just with the box.
     self._patterns = []
     self._pattern_detail = None
     self._last_power_status = None
+    self._menu_values = {}  # MenuId -> current value (MIN_MAX) or choice id (MULTI_CHOICE)
+    self._last_power_request = None  # (chan1, chan2, chan3, chan4), as last requested by any client
 
-    # SetPower is throttled to at most one message every 250ms, same as pattern_gui.py
+    # SetPower is throttled to at most one message every 250ms, same as pattern_gui.py.
+    # The power_request broadcast to other browser clients (see _power_sender) is throttled
+    # along with it, rather than on every slider drag event.
     self._pending_power = None
     self._power_task = None
 
@@ -72,8 +79,13 @@ class WebHub:
     await self._send(websocket, {"type": "patterns", "patterns": self._patterns})
     if self._pattern_detail is not None:
       await self._send(websocket, {"type": "pattern_detail", "detail": self._pattern_detail})
+      for menu_id, value in self._menu_values.items():
+        await self._send(websocket, {"type": "menu_option_changed", "menu_id": menu_id, "value": value})
     if self._last_power_status is not None:
       await self._send(websocket, {"type": "power_status", "status": self._last_power_status})
+    if self._last_power_request is not None:
+      chan1, chan2, chan3, chan4 = self._last_power_request
+      await self._send(websocket, {"type": "power_request", "chan1": chan1, "chan2": chan2, "chan3": chan3, "chan4": chan4})
 
   # ---- browser -> zc95 ----
 
@@ -87,11 +99,15 @@ class WebHub:
       elif cmd == "set_power":
         self._pending_power = (message["chan1"], message["chan2"], message["chan3"], message["chan4"])
       elif cmd == "menu_min_max":
-        await self.zc.request(
-          {"Type": "PatternMinMaxChange", "MenuId": message["menu_id"], "NewValue": message["value"]}, "Ack")
+        menu_id, value = message["menu_id"], message["value"]
+        await self.zc.request({"Type": "PatternMinMaxChange", "MenuId": menu_id, "NewValue": value}, "Ack")
+        self._menu_values[menu_id] = value
+        await self._broadcast({"type": "menu_option_changed", "menu_id": menu_id, "value": value})
       elif cmd == "menu_multi_choice":
-        await self.zc.request(
-          {"Type": "PatternMultiChoiceChange", "MenuId": message["menu_id"], "ChoiceId": message["choice_id"]}, "Ack")
+        menu_id, choice_id = message["menu_id"], message["choice_id"]
+        await self.zc.request({"Type": "PatternMultiChoiceChange", "MenuId": menu_id, "ChoiceId": choice_id}, "Ack")
+        self._menu_values[menu_id] = choice_id
+        await self._broadcast({"type": "menu_option_changed", "menu_id": menu_id, "value": choice_id})
       elif cmd == "soft_button":
         await self.zc.request(
           {"Type": "PatternSoftButton", "Pressed": 1 if message["pressed"] else 0}, "Ack")
@@ -105,12 +121,16 @@ class WebHub:
     await self.zc.request({"Type": "PatternStart", "Index": pattern_id}, "Ack")
     self._pattern_detail = detail
     self._last_power_status = None
+    self._menu_values = {}
+    self._last_power_request = None
     await self._broadcast({"type": "pattern_detail", "detail": detail})
 
   async def _stop_pattern(self):
     await self.zc.request({"Type": "PatternStop"}, "Ack")
     self._pattern_detail = None
     self._last_power_status = None
+    self._menu_values = {}
+    self._last_power_request = None
     await self._broadcast({"type": "pattern_stopped"})
 
   async def _power_sender(self):
@@ -119,6 +139,8 @@ class WebHub:
       if self._pending_power is not None:
         chan1, chan2, chan3, chan4 = self._pending_power
         self._pending_power = None
+        self._last_power_request = (chan1, chan2, chan3, chan4)
+        await self._broadcast({"type": "power_request", "chan1": chan1, "chan2": chan2, "chan3": chan3, "chan4": chan4})
         try:
           await self.zc.request(
             {"Type": "SetPower", "Chan1": chan1, "Chan2": chan2, "Chan3": chan3, "Chan4": chan4}, "Ack")
@@ -137,6 +159,7 @@ class WebHub:
       self._last_power_status = message
       await self._broadcast({"type": "power_status", "status": message})
     elif msg_type == "MenuOptionChanged":
+      self._menu_values[message["MenuId"]] = message["Value"]
       await self._broadcast({"type": "menu_option_changed", "menu_id": message["MenuId"], "value": message["Value"]})
     elif msg_type == "LuaScriptOutput":
       await self._broadcast({"type": "lua_output", "text_type": message["TextType"], "text": message["Text"]})

--- a/remote_access/lib/WebHub.py
+++ b/remote_access/lib/WebHub.py
@@ -1,0 +1,144 @@
+import asyncio
+import json
+import logging
+
+from lib.ZcAsync import ZcAsync, ZcAsyncError
+
+logger = logging.getLogger("webgui")
+
+
+class WebHub:
+  """
+  Owns the single upstream websocket connection to the ZC95, and fans state
+  out to any number of connected browser clients (tabs/devices), so they all
+  see - and can control - the same running pattern.
+
+  Browser clients talk a small JSON "cmd"/"type" protocol to this hub (see
+  web_static/app.js), which is translated to/from the ZC95's own JSON
+  protocol (docs/JSON.md).
+  """
+
+  def __init__(self, ip, debug=False):
+    self.ip = ip
+    self.debug = debug
+    self.zc = ZcAsync(ip, debug)
+    self.zc.set_unsolicited_handler(self._on_unsolicited)
+
+    self._clients = set()
+
+    # Last known state, sent to newly (re)connected browser clients so they sync up
+    self._patterns = []
+    self._pattern_detail = None
+    self._last_power_status = None
+
+    # SetPower is throttled to at most one message every 250ms, same as pattern_gui.py
+    self._pending_power = None
+    self._power_task = None
+
+  async def connect(self):
+    await self.zc.connect()
+    self._power_task = asyncio.create_task(self._power_sender())
+    self._patterns = (await self.zc.request({"Type": "GetPatterns"}, "PatternList"))["Patterns"]
+
+  async def close(self):
+    if self._power_task is not None:
+      self._power_task.cancel()
+    await self.zc.close()
+
+  # ---- browser client management ----
+
+  async def add_client(self, websocket):
+    self._clients.add(websocket)
+    await self._send_full_state(websocket)
+
+  def remove_client(self, websocket):
+    self._clients.discard(websocket)
+
+  async def _send(self, websocket, message):
+    await websocket.send_text(json.dumps(message))
+
+  async def _broadcast(self, message):
+    raw = json.dumps(message)
+    dead = []
+    for client in self._clients:
+      try:
+        await client.send_text(raw)
+      except Exception:
+        dead.append(client)
+    for client in dead:
+      self._clients.discard(client)
+
+  async def _send_full_state(self, websocket):
+    await self._send(websocket, {"type": "patterns", "patterns": self._patterns})
+    if self._pattern_detail is not None:
+      await self._send(websocket, {"type": "pattern_detail", "detail": self._pattern_detail})
+    if self._last_power_status is not None:
+      await self._send(websocket, {"type": "power_status", "status": self._last_power_status})
+
+  # ---- browser -> zc95 ----
+
+  async def handle_client_message(self, message):
+    cmd = message.get("cmd")
+    try:
+      if cmd == "start_pattern":
+        await self._start_pattern(message["id"])
+      elif cmd == "stop_pattern":
+        await self._stop_pattern()
+      elif cmd == "set_power":
+        self._pending_power = (message["chan1"], message["chan2"], message["chan3"], message["chan4"])
+      elif cmd == "menu_min_max":
+        await self.zc.request(
+          {"Type": "PatternMinMaxChange", "MenuId": message["menu_id"], "NewValue": message["value"]}, "Ack")
+      elif cmd == "menu_multi_choice":
+        await self.zc.request(
+          {"Type": "PatternMultiChoiceChange", "MenuId": message["menu_id"], "ChoiceId": message["choice_id"]}, "Ack")
+      elif cmd == "soft_button":
+        await self.zc.request(
+          {"Type": "PatternSoftButton", "Pressed": 1 if message["pressed"] else 0}, "Ack")
+      else:
+        logger.warning("Unknown command from browser client: %s", cmd)
+    except ZcAsyncError as e:
+      await self._broadcast({"type": "error", "message": str(e)})
+
+  async def _start_pattern(self, pattern_id):
+    detail = await self.zc.request({"Type": "GetPatternDetail", "Id": pattern_id}, "PatternDetail")
+    await self.zc.request({"Type": "PatternStart", "Index": pattern_id}, "Ack")
+    self._pattern_detail = detail
+    self._last_power_status = None
+    await self._broadcast({"type": "pattern_detail", "detail": detail})
+
+  async def _stop_pattern(self):
+    await self.zc.request({"Type": "PatternStop"}, "Ack")
+    self._pattern_detail = None
+    self._last_power_status = None
+    await self._broadcast({"type": "pattern_stopped"})
+
+  async def _power_sender(self):
+    while True:
+      await asyncio.sleep(0.25)
+      if self._pending_power is not None:
+        chan1, chan2, chan3, chan4 = self._pending_power
+        self._pending_power = None
+        try:
+          await self.zc.request(
+            {"Type": "SetPower", "Chan1": chan1, "Chan2": chan2, "Chan3": chan3, "Chan4": chan4}, "Ack")
+        except ZcAsyncError as e:
+          await self._broadcast({"type": "error", "message": str(e)})
+
+  # ---- zc95 -> browser (unsolicited, MsgId == -1) ----
+
+  def _on_unsolicited(self, message):
+    asyncio.create_task(self._handle_unsolicited(message))
+
+  async def _handle_unsolicited(self, message):
+    msg_type = message.get("Type")
+
+    if msg_type == "PowerStatus":
+      self._last_power_status = message
+      await self._broadcast({"type": "power_status", "status": message})
+    elif msg_type == "MenuOptionChanged":
+      await self._broadcast({"type": "menu_option_changed", "menu_id": message["MenuId"], "value": message["Value"]})
+    elif msg_type == "LuaScriptOutput":
+      await self._broadcast({"type": "lua_output", "text_type": message["TextType"], "text": message["Text"]})
+    elif msg_type == "LuaScriptError":
+      await self._broadcast({"type": "lua_error"})

--- a/remote_access/lib/ZcAsync.py
+++ b/remote_access/lib/ZcAsync.py
@@ -1,0 +1,96 @@
+import asyncio
+import json
+
+import websockets  # pip3 install websockets
+
+
+class ZcAsyncError(Exception):
+  pass
+
+
+class ZcAsync:
+  """
+  Asyncio websocket connection to a ZC95, plus a thin request/response
+  helper for the JSON message protocol (see docs/JSON.md).
+
+  Unlike ZcWs.py (which is thread based, for use with tkinter), this is
+  meant to be used from a single asyncio event loop, e.g. within a FastAPI
+  app - see webgui.py.
+  """
+
+  def __init__(self, ip, debug=False):
+    self.ip = ip
+    self.debug = debug
+    self._ws = None
+    self._msg_id = 0
+    self._pending = {}  # MsgId -> asyncio.Future
+    self._reader_task = None
+    self._unsolicited_handler = None
+
+  def set_unsolicited_handler(self, handler):
+    """handler(message: dict) is called for messages from the ZC95 with MsgId == -1"""
+    self._unsolicited_handler = handler
+
+  async def connect(self):
+    self._ws = await websockets.connect("ws://" + self.ip + "/stream", ping_interval=6)
+    self._reader_task = asyncio.create_task(self._reader())
+
+  async def close(self):
+    if self._reader_task is not None:
+      self._reader_task.cancel()
+    if self._ws is not None:
+      await self._ws.close()
+
+  async def _reader(self):
+    try:
+      async for raw in self._ws:
+        if self.debug:
+          print("< " + raw)
+
+        message = json.loads(raw)
+        msg_id = message.get("MsgId")
+
+        if msg_id in self._pending:
+          self._pending.pop(msg_id).set_result(message)
+        elif self._unsolicited_handler is not None:
+          self._unsolicited_handler(message)
+    except websockets.ConnectionClosed:
+      pass
+    finally:
+      # Unblock anything still waiting on a response - the connection is gone
+      for future in self._pending.values():
+        if not future.done():
+          future.set_exception(ZcAsyncError("Connection to ZC95 closed"))
+      self._pending.clear()
+
+  async def request(self, message, expected_type, timeout=6.0):
+    """Send a message, and wait for the matching response. Raises ZcAsyncError on failure/timeout."""
+    self._msg_id += 1
+    message["MsgId"] = self._msg_id
+
+    future = asyncio.get_running_loop().create_future()
+    self._pending[self._msg_id] = future
+
+    raw = json.dumps(message)
+    if self.debug:
+      print("> " + raw)
+
+    try:
+      await self._ws.send(raw)
+    except websockets.ConnectionClosed as e:
+      self._pending.pop(self._msg_id, None)
+      raise ZcAsyncError("Connection to ZC95 closed") from e
+
+    try:
+      result = await asyncio.wait_for(future, timeout=timeout)
+    except asyncio.TimeoutError:
+      self._pending.pop(self._msg_id, None)
+      raise ZcAsyncError("Timed out waiting for " + expected_type + " response")
+
+    if result.get("Type") != expected_type:
+      raise ZcAsyncError("Expected " + expected_type + " message, got " + str(result.get("Type")))
+
+    if result.get("Result") != "OK":
+      raise ZcAsyncError(result.get("Error") or "Result not OK")
+
+    return result

--- a/remote_access/requirements-webgui.txt
+++ b/remote_access/requirements-webgui.txt
@@ -1,0 +1,3 @@
+fastapi>=0.100
+uvicorn[standard]>=0.23
+websockets>=11

--- a/remote_access/web_static/app.css
+++ b/remote_access/web_static/app.css
@@ -13,8 +13,10 @@
   --max-power: #4d7cf0;
 }
 
+/* No explicit toggle choice stored -> follow the browser/OS preference live (falls back
+   to the dark :root defaults above if the browser doesn't report a preference at all) */
 @media (prefers-color-scheme: light) {
-  :root {
+  :root:not([data-theme="dark"]) {
     --bg: #f5f5f7;
     --bg-elevated: #ffffff;
     --text: #1c1c1e;
@@ -28,6 +30,22 @@
     --actual-power: #d6a600;
     --max-power: #3b63c2;
   }
+}
+
+/* Explicit choice made via the theme toggle (persisted client-side in localStorage) */
+:root[data-theme="light"] {
+  --bg: #f5f5f7;
+  --bg-elevated: #ffffff;
+  --text: #1c1c1e;
+  --text-muted: #6b6b70;
+  --border: #d8d8de;
+  --accent: #c62b6b;
+  --accent-text: #ffffff;
+  --danger: #b3261e;
+  --ok: #2e7d43;
+  --warn: #a06800;
+  --actual-power: #d6a600;
+  --max-power: #3b63c2;
 }
 
 * {
@@ -59,6 +77,29 @@ header h1 {
   margin: 0;
   font-size: 1.2rem;
   letter-spacing: 0.05em;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.btn-icon {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text);
+  border-radius: 999px;
+  width: 34px;
+  height: 34px;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
 }
 
 .status {
@@ -100,6 +141,16 @@ label {
 h2 {
   margin: 0;
   font-size: 1.1rem;
+}
+
+.badge-warning {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--warn);
+  border: 1px solid var(--warn);
+  border-radius: 999px;
+  padding: 2px 8px;
+  white-space: nowrap;
 }
 
 .row {
@@ -318,6 +369,10 @@ input[type="range"]::-moz-range-thumb {
   width: 2px;
   left: 100%;
   background: var(--danger);
+}
+
+.channel-slider-row {
+  margin-top: 10px;
 }
 
 #log-section {

--- a/remote_access/web_static/app.css
+++ b/remote_access/web_static/app.css
@@ -1,0 +1,346 @@
+:root {
+  --bg: #14151a;
+  --bg-elevated: #1f2129;
+  --text: #f0f0f2;
+  --text-muted: #9a9ba6;
+  --border: #33333f;
+  --accent: #c62b6b;
+  --accent-text: #ffffff;
+  --danger: #b3261e;
+  --ok: #3ba55c;
+  --warn: #e0a020;
+  --actual-power: #ffd23f;
+  --max-power: #4d7cf0;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f5f5f7;
+    --bg-elevated: #ffffff;
+    --text: #1c1c1e;
+    --text-muted: #6b6b70;
+    --border: #d8d8de;
+    --accent: #c62b6b;
+    --accent-text: #ffffff;
+    --danger: #b3261e;
+    --ok: #2e7d43;
+    --warn: #a06800;
+    --actual-power: #d6a600;
+    --max-power: #3b63c2;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  -webkit-tap-highlight-color: transparent;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 10;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.05em;
+}
+
+.status {
+  font-size: 0.85rem;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+
+.status-connected { color: var(--ok); border-color: var(--ok); }
+.status-connecting { color: var(--warn); border-color: var(--warn); }
+.status-disconnected { color: var(--danger); border-color: var(--danger); }
+
+main {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+section {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+}
+
+label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+
+h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.row-space-between {
+  justify-content: space-between;
+}
+
+select {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.btn {
+  appearance: none;
+  border: none;
+  border-radius: 10px;
+  padding: 12px 18px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  touch-action: manipulation;
+  user-select: none;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--accent-text);
+}
+
+.btn-danger {
+  background: var(--danger);
+  color: #fff;
+}
+
+.btn-secondary {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.btn-hold {
+  width: 100%;
+  padding: 18px;
+}
+
+.btn-hold.pressed {
+  background: var(--accent);
+  color: var(--accent-text);
+}
+
+.btn-step {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  font-size: 1.3rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  padding: 4px 0;
+  cursor: pointer;
+}
+
+#soft-button-row {
+  margin-top: 14px;
+}
+
+#menu-items {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.menu-title {
+  font-size: 0.9rem;
+}
+
+.menu-value {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.menu-slider-row {
+  margin-top: 8px;
+}
+
+input[type="range"] {
+  flex: 1;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 34px;
+  background: transparent;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--border);
+}
+
+input[type="range"]::-moz-range-track {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--border);
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 28px;
+  height: 28px;
+  margin-top: -10px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid var(--accent-text);
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid var(--accent-text);
+}
+
+.choice-group {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.choice-btn {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.choice-btn.active {
+  background: var(--accent);
+  color: var(--accent-text);
+  border-color: var(--accent);
+}
+
+.channels {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.channel-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.channel-percent {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.channel-bar {
+  position: relative;
+  height: 10px;
+  border-radius: 5px;
+  background: var(--border);
+  margin: 8px 0 2px;
+  overflow: hidden;
+}
+
+.channel-bar > div {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: 5px;
+}
+
+.channel-bar-max {
+  background: var(--max-power);
+  width: 0%;
+}
+
+.channel-bar-actual {
+  background: var(--actual-power);
+  width: 0%;
+  opacity: 0.9;
+}
+
+.channel-bar-limit {
+  width: 2px;
+  left: 100%;
+  background: var(--danger);
+}
+
+#log-section {
+  border-style: dashed;
+}
+
+#log {
+  margin-top: 8px;
+  max-height: 180px;
+  overflow-y: auto;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-muted);
+}
+
+#log .log-error {
+  color: var(--danger);
+}
+
+@media (min-width: 640px) {
+  main {
+    max-width: 640px;
+  }
+}

--- a/remote_access/web_static/app.js
+++ b/remote_access/web_static/app.js
@@ -1,0 +1,321 @@
+(() => {
+  "use strict";
+
+  const statusEl = document.getElementById("status");
+  const patternPickerEl = document.getElementById("pattern-picker");
+  const patternSelectEl = document.getElementById("pattern-select");
+  const startBtn = document.getElementById("start-btn");
+  const patternRunningEl = document.getElementById("pattern-running");
+  const patternNameEl = document.getElementById("pattern-name");
+  const stopBtn = document.getElementById("stop-btn");
+  const softButtonRowEl = document.getElementById("soft-button-row");
+  const softButtonEl = document.getElementById("soft-button");
+  const menuItemsEl = document.getElementById("menu-items");
+  const channelsEl = document.getElementById("channels");
+  const logEl = document.getElementById("log");
+  const logToggleBtn = document.getElementById("log-toggle");
+
+  const tmplMinMax = document.getElementById("tmpl-min-max");
+  const tmplMultiChoice = document.getElementById("tmpl-multi-choice");
+  const tmplChannel = document.getElementById("tmpl-channel");
+
+  let ws = null;
+  let reconnectDelayMs = 1000;
+  let patterns = [];
+  const powerValues = [0, 0, 0, 0]; // Chan1..Chan4, as requested locally via the sliders
+  const channelEls = []; // index 0..3 -> {slider, percent, barMax, barActual, barLimit}
+
+  function log(text, isError) {
+    const line = document.createElement("div");
+    if (isError) line.className = "log-error";
+    line.textContent = new Date().toLocaleTimeString() + "  " + text;
+    logEl.appendChild(line);
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+
+  function setStatus(state, text) {
+    statusEl.className = "status status-" + state;
+    statusEl.textContent = text;
+  }
+
+  function send(message) {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(message));
+    }
+  }
+
+  function connect() {
+    setStatus("connecting", "connecting…");
+    ws = new WebSocket("ws://" + location.host + "/ws");
+
+    ws.onopen = () => {
+      reconnectDelayMs = 1000;
+      setStatus("connected", "connected");
+      log("Connected to server");
+    };
+
+    ws.onclose = () => {
+      setStatus("disconnected", "disconnected");
+      log("Disconnected from server, retrying…", true);
+      setTimeout(connect, reconnectDelayMs);
+      reconnectDelayMs = Math.min(reconnectDelayMs * 2, 10000);
+    };
+
+    ws.onerror = () => {
+      ws.close();
+    };
+
+    ws.onmessage = (event) => {
+      handleMessage(JSON.parse(event.data));
+    };
+  }
+
+  function handleMessage(message) {
+    switch (message.type) {
+      case "patterns":
+        patterns = message.patterns;
+        renderPatternList();
+        break;
+      case "pattern_detail":
+        showPatternRunning(message.detail);
+        break;
+      case "pattern_stopped":
+        showPatternPicker();
+        break;
+      case "power_status":
+        updatePowerStatus(message.status);
+        break;
+      case "menu_option_changed":
+        updateMenuOption(message.menu_id, message.value);
+        break;
+      case "lua_output":
+        log((message.text_type === "Error" ? "[error] " : "[print] ") + message.text, message.text_type === "Error");
+        break;
+      case "lua_error":
+        log("Script stopped due to an error", true);
+        break;
+      case "error":
+        log(message.message, true);
+        break;
+    }
+  }
+
+  // ---- pattern picker ----
+
+  function renderPatternList() {
+    patternSelectEl.innerHTML = "";
+    for (const pattern of patterns) {
+      const option = document.createElement("option");
+      option.value = pattern.Id;
+      option.textContent = pattern.Name;
+      patternSelectEl.appendChild(option);
+    }
+  }
+
+  startBtn.addEventListener("click", () => {
+    const id = parseInt(patternSelectEl.value, 10);
+    if (!Number.isNaN(id)) {
+      send({ cmd: "start_pattern", id });
+    }
+  });
+
+  stopBtn.addEventListener("click", () => {
+    send({ cmd: "stop_pattern" });
+  });
+
+  function showPatternPicker() {
+    patternPickerEl.hidden = false;
+    patternRunningEl.hidden = true;
+  }
+
+  // ---- running pattern: menu items + soft button + channels ----
+
+  const minMaxControls = new Map(); // menuId -> {slider, valueEl, min, max, step}
+  const multiChoiceControls = new Map(); // menuId -> {buttons: Map(choiceId -> el)}
+
+  function showPatternRunning(detail) {
+    patternPickerEl.hidden = true;
+    patternRunningEl.hidden = false;
+    patternNameEl.textContent = detail.Name;
+
+    softButtonRowEl.hidden = !(detail.ButtonA && detail.ButtonA.length > 0);
+    softButtonEl.textContent = detail.ButtonA || "Soft button";
+
+    menuItemsEl.innerHTML = "";
+    minMaxControls.clear();
+    multiChoiceControls.clear();
+
+    for (const item of detail.MenuItems) {
+      if (item.Type === "MIN_MAX") {
+        buildMinMax(item);
+      } else if (item.Type === "MULTI_CHOICE") {
+        buildMultiChoice(item);
+      }
+    }
+
+    buildChannels();
+  }
+
+  function buildMinMax(item) {
+    const node = tmplMinMax.content.firstElementChild.cloneNode(true);
+    const title = item.Title + (item.UoM ? " (" + item.UoM + ")" : "");
+    node.querySelector(".menu-title").textContent = title;
+
+    const valueEl = node.querySelector(".menu-value");
+    const slider = node.querySelector(".menu-slider");
+    slider.min = item.Min;
+    slider.max = item.Max;
+    slider.step = item.IncrementStep;
+    slider.value = item.Default;
+    valueEl.textContent = item.Default;
+
+    const control = { slider, valueEl, min: item.Min, max: item.Max, step: item.IncrementStep };
+    minMaxControls.set(item.Id, control);
+
+    slider.addEventListener("input", () => {
+      valueEl.textContent = slider.value;
+    });
+    slider.addEventListener("change", () => {
+      send({ cmd: "menu_min_max", menu_id: item.Id, value: parseInt(slider.value, 10) });
+    });
+
+    node.querySelector(".btn-dec").addEventListener("click", () => {
+      stepMinMax(item.Id, -control.step);
+    });
+    node.querySelector(".btn-inc").addEventListener("click", () => {
+      stepMinMax(item.Id, control.step);
+    });
+
+    menuItemsEl.appendChild(node);
+  }
+
+  function stepMinMax(menuId, delta) {
+    const control = minMaxControls.get(menuId);
+    if (!control) return;
+    let value = parseInt(control.slider.value, 10) + delta;
+    value = Math.max(control.min, Math.min(control.max, value));
+    control.slider.value = value;
+    control.valueEl.textContent = value;
+    send({ cmd: "menu_min_max", menu_id: menuId, value });
+  }
+
+  function buildMultiChoice(item) {
+    const node = tmplMultiChoice.content.firstElementChild.cloneNode(true);
+    node.querySelector(".menu-title").textContent = item.Title;
+    const group = node.querySelector(".choice-group");
+
+    const buttons = new Map();
+    for (const choice of item.Choices) {
+      const btn = document.createElement("button");
+      btn.className = "choice-btn";
+      btn.type = "button";
+      btn.textContent = choice.Name;
+      if (choice.Id === item.Default) btn.classList.add("active");
+      btn.addEventListener("click", () => {
+        setMultiChoiceActive(item.Id, choice.Id);
+        send({ cmd: "menu_multi_choice", menu_id: item.Id, choice_id: choice.Id });
+      });
+      group.appendChild(btn);
+      buttons.set(choice.Id, btn);
+    }
+
+    multiChoiceControls.set(item.Id, { buttons });
+    menuItemsEl.appendChild(node);
+  }
+
+  function setMultiChoiceActive(menuId, choiceId) {
+    const control = multiChoiceControls.get(menuId);
+    if (!control) return;
+    for (const [id, btn] of control.buttons) {
+      btn.classList.toggle("active", id === choiceId);
+    }
+  }
+
+  function updateMenuOption(menuId, value) {
+    if (minMaxControls.has(menuId)) {
+      const control = minMaxControls.get(menuId);
+      control.slider.value = value;
+      control.valueEl.textContent = value;
+    } else if (multiChoiceControls.has(menuId)) {
+      setMultiChoiceActive(menuId, value);
+    }
+  }
+
+  // Soft button: held down while pressed, released on pointer up/cancel/leave
+  function bindSoftButton() {
+    let pressed = false;
+
+    const press = (e) => {
+      e.preventDefault();
+      if (pressed) return;
+      pressed = true;
+      softButtonEl.classList.add("pressed");
+      send({ cmd: "soft_button", pressed: true });
+    };
+
+    const release = (e) => {
+      if (!pressed) return;
+      pressed = false;
+      softButtonEl.classList.remove("pressed");
+      send({ cmd: "soft_button", pressed: false });
+    };
+
+    softButtonEl.addEventListener("pointerdown", press);
+    softButtonEl.addEventListener("pointerup", release);
+    softButtonEl.addEventListener("pointercancel", release);
+    softButtonEl.addEventListener("pointerleave", release);
+    softButtonEl.style.touchAction = "none";
+  }
+  bindSoftButton();
+
+  // ---- channels (power sliders) ----
+
+  function buildChannels() {
+    channelsEl.innerHTML = "";
+    channelEls.length = 0;
+
+    for (let i = 0; i < 4; i++) {
+      const channelNumber = i + 1;
+      const node = tmplChannel.content.firstElementChild.cloneNode(true);
+      node.querySelector(".channel-label").textContent = "Channel " + channelNumber;
+
+      const slider = node.querySelector(".channel-slider");
+      const percentEl = node.querySelector(".channel-percent");
+      const barMax = node.querySelector(".channel-bar-max");
+      const barActual = node.querySelector(".channel-bar-actual");
+      const barLimit = node.querySelector(".channel-bar-limit");
+
+      slider.value = 0;
+      powerValues[i] = 0;
+
+      slider.addEventListener("input", () => {
+        const value = parseInt(slider.value, 10);
+        powerValues[i] = value;
+        percentEl.textContent = Math.round(value / 10) + "%";
+        send({ cmd: "set_power", chan1: powerValues[0], chan2: powerValues[1], chan3: powerValues[2], chan4: powerValues[3] });
+      });
+
+      channelEls[i] = { slider, percentEl, barMax, barActual, barLimit };
+      channelsEl.appendChild(node);
+    }
+  }
+
+  function updatePowerStatus(status) {
+    for (const channel of status.Channels) {
+      const el = channelEls[channel.Channel - 1];
+      if (!el) continue;
+      el.barMax.style.width = (channel.MaxOutputPower / 10) + "%";
+      el.barActual.style.width = (channel.OutputPower / 10) + "%";
+      el.barLimit.style.left = (channel.PowerLimit / 10) + "%";
+    }
+  }
+
+  // ---- log panel ----
+
+  logToggleBtn.addEventListener("click", () => {
+    logEl.hidden = !logEl.hidden;
+    logToggleBtn.textContent = logEl.hidden ? "Show log" : "Hide log";
+  });
+
+  connect();
+})();

--- a/remote_access/web_static/app.js
+++ b/remote_access/web_static/app.js
@@ -7,7 +7,9 @@
   const startBtn = document.getElementById("start-btn");
   const patternRunningEl = document.getElementById("pattern-running");
   const patternNameEl = document.getElementById("pattern-name");
+  const triphaseBadgeEl = document.getElementById("triphase-badge");
   const stopBtn = document.getElementById("stop-btn");
+  const themeToggleBtn = document.getElementById("theme-toggle");
   const softButtonRowEl = document.getElementById("soft-button-row");
   const softButtonEl = document.getElementById("soft-button");
   const menuItemsEl = document.getElementById("menu-items");
@@ -42,6 +44,20 @@
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify(message));
     }
+  }
+
+  // Other tabs/devices can move these same sliders at any time (see "menu_option_changed"
+  // and "power_request" broadcasts below) - this stops an incoming update from yanking a
+  // slider out from under a finger that's actively dragging it.
+  function bindDragGuard(slider) {
+    const setDragging = (dragging) => { slider.dataset.dragging = dragging ? "1" : ""; };
+    slider.addEventListener("pointerdown", () => setDragging(true));
+    slider.addEventListener("pointerup", () => setDragging(false));
+    slider.addEventListener("pointercancel", () => setDragging(false));
+  }
+
+  function isDragging(slider) {
+    return slider.dataset.dragging === "1";
   }
 
   function connect() {
@@ -84,6 +100,9 @@
         break;
       case "power_status":
         updatePowerStatus(message.status);
+        break;
+      case "power_request":
+        updatePowerRequest(message);
         break;
       case "menu_option_changed":
         updateMenuOption(message.menu_id, message.value);
@@ -138,6 +157,11 @@
     patternRunningEl.hidden = false;
     patternNameEl.textContent = detail.Name;
 
+    // PatternDetail doesn't carry the "(!)" triphase warning prefix that PatternList's
+    // Name does (a ZC95 firmware quirk), so cross-reference the pattern list we already have
+    const listEntry = patterns.find((p) => p.Id === detail.Id);
+    triphaseBadgeEl.hidden = !(listEntry && listEntry.Name.startsWith("(!)"));
+
     softButtonRowEl.hidden = !(detail.ButtonA && detail.ButtonA.length > 0);
     softButtonEl.textContent = detail.ButtonA || "Soft button";
 
@@ -171,6 +195,7 @@
 
     const control = { slider, valueEl, min: item.Min, max: item.Max, step: item.IncrementStep };
     minMaxControls.set(item.Id, control);
+    bindDragGuard(slider);
 
     slider.addEventListener("input", () => {
       valueEl.textContent = slider.value;
@@ -234,6 +259,7 @@
   function updateMenuOption(menuId, value) {
     if (minMaxControls.has(menuId)) {
       const control = minMaxControls.get(menuId);
+      if (isDragging(control.slider)) return;
       control.slider.value = value;
       control.valueEl.textContent = value;
     } else if (multiChoiceControls.has(menuId)) {
@@ -270,6 +296,8 @@
 
   // ---- channels (power sliders) ----
 
+  const CHANNEL_STEP = 10; // 1000-basis units, i.e. 1%
+
   function buildChannels() {
     channelsEl.innerHTML = "";
     channelEls.length = 0;
@@ -287,17 +315,34 @@
 
       slider.value = 0;
       powerValues[i] = 0;
+      bindDragGuard(slider);
 
       slider.addEventListener("input", () => {
-        const value = parseInt(slider.value, 10);
-        powerValues[i] = value;
-        percentEl.textContent = Math.round(value / 10) + "%";
-        send({ cmd: "set_power", chan1: powerValues[0], chan2: powerValues[1], chan3: powerValues[2], chan4: powerValues[3] });
+        setChannelPower(i, parseInt(slider.value, 10));
+      });
+
+      node.querySelector(".btn-dec").addEventListener("click", () => {
+        stepChannelPower(i, -CHANNEL_STEP);
+      });
+      node.querySelector(".btn-inc").addEventListener("click", () => {
+        stepChannelPower(i, CHANNEL_STEP);
       });
 
       channelEls[i] = { slider, percentEl, barMax, barActual, barLimit };
       channelsEl.appendChild(node);
     }
+  }
+
+  function setChannelPower(index, value) {
+    powerValues[index] = value;
+    channelEls[index].slider.value = value;
+    channelEls[index].percentEl.textContent = Math.round(value / 10) + "%";
+    send({ cmd: "set_power", chan1: powerValues[0], chan2: powerValues[1], chan3: powerValues[2], chan4: powerValues[3] });
+  }
+
+  function stepChannelPower(index, delta) {
+    const value = Math.max(0, Math.min(1000, powerValues[index] + delta));
+    setChannelPower(index, value);
   }
 
   function updatePowerStatus(status) {
@@ -310,12 +355,74 @@
     }
   }
 
+  // Requested power level as set by any connected client (this tab or another one) -
+  // keeps the sliders themselves, not just the bar graphs above, in sync across tabs/devices.
+  function updatePowerRequest(message) {
+    const values = [message.chan1, message.chan2, message.chan3, message.chan4];
+    for (let i = 0; i < 4; i++) {
+      const el = channelEls[i];
+      if (!el || isDragging(el.slider)) continue;
+      powerValues[i] = values[i];
+      el.slider.value = values[i];
+      el.percentEl.textContent = Math.round(values[i] / 10) + "%";
+    }
+  }
+
   // ---- log panel ----
 
   logToggleBtn.addEventListener("click", () => {
     logEl.hidden = !logEl.hidden;
     logToggleBtn.textContent = logEl.hidden ? "Show log" : "Hide log";
   });
+
+  // ---- theme toggle (client-side only, persisted in localStorage) ----
+  //
+  // No stored preference -> no data-theme attribute is set, so the CSS media query follows
+  // the browser/OS preference live (and falls back to dark if the browser reports none).
+  // Once toggled, the explicit choice is pinned via data-theme and persisted, taking over
+  // from the live system preference from then on.
+
+  const THEME_KEY = "zc95-theme";
+
+  function systemPrefersLight() {
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches;
+  }
+
+  function currentTheme() {
+    return document.documentElement.getAttribute("data-theme") || (systemPrefersLight() ? "light" : "dark");
+  }
+
+  function updateThemeToggleIcon() {
+    const theme = currentTheme();
+    themeToggleBtn.textContent = theme === "dark" ? "🌙" : "☀️";
+    themeToggleBtn.title = theme === "dark" ? "Switch to light theme" : "Switch to dark theme";
+  }
+
+  function initTheme() {
+    let stored = null;
+    try {
+      stored = localStorage.getItem(THEME_KEY);
+    } catch (e) {
+      // localStorage unavailable (private browsing etc.) - just follow the system preference
+    }
+    if (stored === "dark" || stored === "light") {
+      document.documentElement.setAttribute("data-theme", stored);
+    }
+    updateThemeToggleIcon();
+  }
+
+  themeToggleBtn.addEventListener("click", () => {
+    const next = currentTheme() === "dark" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", next);
+    try {
+      localStorage.setItem(THEME_KEY, next);
+    } catch (e) {
+      // ignore - theme just won't persist across reloads
+    }
+    updateThemeToggleIcon();
+  });
+
+  initTheme();
 
   connect();
 })();

--- a/remote_access/web_static/index.html
+++ b/remote_access/web_static/index.html
@@ -9,7 +9,10 @@
 <body>
   <header>
     <h1>ZC95</h1>
-    <span id="status" class="status status-connecting">connecting&hellip;</span>
+    <div class="header-right">
+      <span id="status" class="status status-connecting">connecting&hellip;</span>
+      <button id="theme-toggle" class="btn-icon" title="Toggle light/dark theme" aria-label="Toggle light/dark theme">🌙</button>
+    </div>
   </header>
 
   <main>
@@ -23,7 +26,10 @@
 
     <section id="pattern-running" hidden>
       <div class="row row-space-between">
-        <h2 id="pattern-name"></h2>
+        <div class="row">
+          <h2 id="pattern-name"></h2>
+          <span id="triphase-badge" class="badge-warning" title="Uses triphase - channel isolation is disabled" hidden>(!) triphase</span>
+        </div>
         <button id="stop-btn" class="btn btn-danger">Stop</button>
       </div>
 
@@ -74,7 +80,11 @@
         <div class="channel-bar-max"></div>
         <div class="channel-bar-actual"></div>
       </div>
-      <input type="range" class="channel-slider" min="0" max="1000" step="10" value="0">
+      <div class="row channel-slider-row">
+        <button class="btn btn-step btn-dec">&minus;</button>
+        <input type="range" class="channel-slider" min="0" max="1000" step="10" value="0">
+        <button class="btn btn-step btn-inc">&plus;</button>
+      </div>
     </div>
   </template>
 

--- a/remote_access/web_static/index.html
+++ b/remote_access/web_static/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <title>ZC95</title>
+  <link rel="stylesheet" href="app.css">
+</head>
+<body>
+  <header>
+    <h1>ZC95</h1>
+    <span id="status" class="status status-connecting">connecting&hellip;</span>
+  </header>
+
+  <main>
+    <section id="pattern-picker">
+      <label for="pattern-select">Pattern</label>
+      <div class="row">
+        <select id="pattern-select"></select>
+        <button id="start-btn" class="btn btn-primary">Start</button>
+      </div>
+    </section>
+
+    <section id="pattern-running" hidden>
+      <div class="row row-space-between">
+        <h2 id="pattern-name"></h2>
+        <button id="stop-btn" class="btn btn-danger">Stop</button>
+      </div>
+
+      <div id="soft-button-row" class="row" hidden>
+        <button id="soft-button" class="btn btn-secondary btn-hold">Soft button</button>
+      </div>
+
+      <div id="menu-items"></div>
+
+      <div id="channels" class="channels"></div>
+    </section>
+
+    <section id="log-section">
+      <button id="log-toggle" class="btn btn-link">Show log</button>
+      <pre id="log" hidden></pre>
+    </section>
+  </main>
+
+  <template id="tmpl-min-max">
+    <div class="menu-item menu-item-min-max">
+      <div class="row row-space-between">
+        <span class="menu-title"></span>
+        <span class="menu-value"></span>
+      </div>
+      <div class="row menu-slider-row">
+        <button class="btn btn-step btn-dec">&minus;</button>
+        <input type="range" class="menu-slider">
+        <button class="btn btn-step btn-inc">&plus;</button>
+      </div>
+    </div>
+  </template>
+
+  <template id="tmpl-multi-choice">
+    <div class="menu-item menu-item-multi-choice">
+      <span class="menu-title"></span>
+      <div class="choice-group"></div>
+    </div>
+  </template>
+
+  <template id="tmpl-channel">
+    <div class="channel">
+      <div class="row row-space-between">
+        <span class="channel-label"></span>
+        <span class="channel-percent">0%</span>
+      </div>
+      <div class="channel-bar">
+        <div class="channel-bar-limit"></div>
+        <div class="channel-bar-max"></div>
+        <div class="channel-bar-actual"></div>
+      </div>
+      <input type="range" class="channel-slider" min="0" max="1000" step="10" value="0">
+    </div>
+  </template>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/remote_access/webgui.py
+++ b/remote_access/webgui.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Mobile-first web based remote control for the ZC95.
+
+Unlike pattern_gui.py (tkinter - local machine only, single controller,
+pattern picked upfront on the command line), this starts a small web
+server that can be opened from any browser on the same network - e.g. a
+phone. Multiple devices/tabs can be connected at once; they all control,
+and see the state of, the same ZC95, since this process holds the single
+upstream connection to the box and fans state out to every connected
+browser (see lib/WebHub.py).
+
+Requires: fastapi, uvicorn[standard] (see requirements-webgui.txt)
+
+Usage:
+    python3 webgui.py --ip 192.168.1.137
+
+Then, from any device on the same network, browse to:
+    http://<ip address of the machine running this script>:8080/
+"""
+import argparse
+import logging
+import os
+from contextlib import asynccontextmanager
+
+import uvicorn
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.staticfiles import StaticFiles
+
+from lib.WebHub import WebHub
+
+logger = logging.getLogger("webgui")
+
+STATIC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "web_static")
+
+hub = None  # set in main(), used by the websocket_endpoint() and lifespan() closures below
+
+
+@asynccontextmanager
+async def lifespan(app):
+  logger.info("Connecting to ZC95 at %s", hub.ip)
+  await hub.connect()
+  logger.info("Connected")
+  try:
+    yield
+  finally:
+    await hub.close()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+  await websocket.accept()
+  await hub.add_client(websocket)
+  try:
+    while True:
+      message = await websocket.receive_json()
+      await hub.handle_client_message(message)
+  except WebSocketDisconnect:
+    pass
+  finally:
+    hub.remove_client(websocket)
+
+
+# Mounted last so it doesn't shadow the /ws route above; serves web_static/index.html at "/"
+app.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")
+
+
+def main():
+  global hub
+
+  parser = argparse.ArgumentParser(description="Web based remote control for ZC95")
+  parser.add_argument("--ip", required=True, help="IP address of ZC95")
+  parser.add_argument("--port", type=int, default=8080, help="Port to serve the web interface on (default: 8080)")
+  parser.add_argument("--bind", default="0.0.0.0",
+                       help="Address to bind the web server to (default: 0.0.0.0, i.e. all interfaces, so it's reachable from your phone)")
+  parser.add_argument("--debug", action="store_true", help="Show messages sent/received to/from the ZC95")
+  args = parser.parse_args()
+
+  logging.basicConfig(level=logging.INFO)
+  hub = WebHub(args.ip, args.debug)
+
+  print("Starting web interface - browse to http://<ip of this machine>:" + str(args.port) + "/ from your phone/tablet/PC")
+  uvicorn.run(app, host=args.bind, port=args.port)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary
- Adds `webgui.py`: a mobile-first web GUI for remote pattern control, as an alternative to `pattern_gui.py` (tkinter, local-machine only). Documented in `docs/RemoteAccess.md`.
- FastAPI + `websockets` backend acts as a hub: it holds the single upstream connection to the ZC95 and fans state out to any number of connected browser tabs/devices, so they all control (and stay in sync with) the same running pattern — power sliders, MIN_MAX/MULTI_CHOICE menu items, and multi-choice selections all sync bidirectionally across tabs, including for tabs that join mid-session.
- Full-width channel power sliders with flanking `-`/`+` buttons (1% = 10 basis-unit steps) for smoother, more precise control than the previous narrow default-width slider.
- Shows a "(!) triphase" warning badge on the running-pattern header for triphase-enabled scripts, mirroring the front panel's own `(!)` indicator (worked around a `PatternDetail` firmware quirk client-side, see commit message for details - no firmware changes needed).
- Client-side light/dark theme toggle in the header, persisted via `localStorage`; follows the browser/OS preference live until explicitly toggled.
- New `remote_access/requirements-webgui.txt` for the extra dependencies (`fastapi`, `uvicorn[standard]`, `websockets`).

## Test plan
- [x] Verified end-to-end against a stub ZC95 websocket server implementing the JSON protocol: pattern list, start/stop, MIN_MAX/MULTI_CHOICE changes, soft button, power sliders, `PowerStatus` broadcasts.
- [x] Verified in headless Chromium via Playwright: mobile viewport (390px) with no horizontal overflow, multi-tab sync including late-joining tabs, drag-guard behaviour (an incoming sync doesn't yank a slider mid-drag), triphase badge show/hide, theme toggle + persistence across reload.
- [x] Tested against a real ZC95 MKII - built-in patterns and a custom uploaded Lua script both worked as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nDvD6cgimt84UdZr9zh34
